### PR TITLE
Feat/tool call iteration count parameter

### DIFF
--- a/Releases/0.10.10.md
+++ b/Releases/0.10.10.md
@@ -1,0 +1,5 @@
+# 0.10.10 release
+
+- Adds `WithMaxIterations()` to `ToolsConfigurationBuilder` and `McpContext` to override the default tool-call iteration limit.
+- Fix: MCP loop now sends a final synthesis request instead of returning an error string when the iteration cap is reached.
+- Fix: Gemini/Vertex backends now throw `NotSupportedException` when `WithMaxIterations` is used instead of silently ignoring the value.

--- a/src/MaIN.Core/.nuspec
+++ b/src/MaIN.Core/.nuspec
@@ -2,7 +2,7 @@
 <package>
   <metadata>
     <id>MaIN.NET</id>
-    <version>0.10.9</version>
+    <version>0.10.10</version>
     <authors>Wisedev</authors>
     <owners>Wisedev</owners>
     <icon>favicon.png</icon>

--- a/src/MaIN.Core/Hub/Contexts/Interfaces/McpContext/IMcpContext.cs
+++ b/src/MaIN.Core/Hub/Contexts/Interfaces/McpContext/IMcpContext.cs
@@ -1,4 +1,4 @@
-﻿using MaIN.Domain.Configuration;
+using MaIN.Domain.Configuration;
 using MaIN.Domain.Entities;
 using MaIN.Services.Services.Models;
 
@@ -21,6 +21,12 @@ public interface IMcpContext
     /// <param name="backendType">The <see cref="BackendType"/> enum value specifying which backend implementation to use.</param>
     /// <returns>The context instance implementing <see cref="IMcpContext"/> for method chaining.</returns>
     IMcpContext WithBackend(BackendType backendType);
+
+    /// <summary>
+    /// Sets the maximum number of tool-call iterations allowed in a single MCP prompt.
+    /// Overrides the default limit of 10. Must be at least 1.
+    /// </summary>
+    IMcpContext WithMaxIterations(int maxIterations);
 
     /// <summary>
     /// Asynchronously processes a prompt through the configured MCP service, sending the prompt to the MCP server and returning the processed result.

--- a/src/MaIN.Core/Hub/Contexts/Interfaces/McpContext/IMcpContext.cs
+++ b/src/MaIN.Core/Hub/Contexts/Interfaces/McpContext/IMcpContext.cs
@@ -26,6 +26,10 @@ public interface IMcpContext
     /// Sets the maximum number of tool-call iterations allowed in a single MCP prompt.
     /// Overrides the default limit of 10. Must be at least 1.
     /// </summary>
+    /// <remarks>
+    /// Not supported for <see cref="BackendType.Gemini"/> and <see cref="BackendType.Vertex"/> backends -
+    /// a <see cref="NotSupportedException"/> will be thrown at runtime when <see cref="PromptAsync"/> is called.
+    /// </remarks>
     IMcpContext WithMaxIterations(int maxIterations);
 
     /// <summary>

--- a/src/MaIN.Core/Hub/Contexts/McpContext.cs
+++ b/src/MaIN.Core/Hub/Contexts/McpContext.cs
@@ -42,11 +42,7 @@ public sealed class McpContext : IMcpContext
 
     public IMcpContext WithMaxIterations(int maxIterations)
     {
-        if (maxIterations < 1)
-        {
-            throw new InvalidToolIterationsException(maxIterations);
-        }
-
+        InvalidToolIterationsException.ThrowIfInvalid(maxIterations);
         _maxIterations = maxIterations;
         return this;
     }

--- a/src/MaIN.Core/Hub/Contexts/McpContext.cs
+++ b/src/MaIN.Core/Hub/Contexts/McpContext.cs
@@ -2,6 +2,7 @@ using MaIN.Core.Hub.Contexts.Interfaces.McpContext;
 using MaIN.Domain.Configuration;
 using MaIN.Domain.Entities;
 using MaIN.Domain.Exceptions.MPC;
+using MaIN.Domain.Exceptions.Tools;
 using MaIN.Services.Constants;
 using MaIN.Services.Services.Abstract;
 using MaIN.Services.Services.Models;
@@ -13,6 +14,7 @@ public sealed class McpContext : IMcpContext
     private readonly IMcpService _mcpService;
     private Mcp? _mcpConfig;
     private BackendType? _explicitBackend;
+    private int? _maxIterations;
 
     internal McpContext(IMcpService mcpService)
     {
@@ -24,7 +26,10 @@ public sealed class McpContext : IMcpContext
     {
         _mcpConfig = mcpConfig;
         if (_explicitBackend.HasValue)
+        {
             _mcpConfig.Backend = _explicitBackend;
+        }
+
         return this;
     }
 
@@ -35,18 +40,29 @@ public sealed class McpContext : IMcpContext
         return this;
     }
 
+    public IMcpContext WithMaxIterations(int maxIterations)
+    {
+        if (maxIterations < 1)
+        {
+            throw new InvalidToolIterationsException(maxIterations);
+        }
+
+        _maxIterations = maxIterations;
+        return this;
+    }
+
     public async Task<McpResult> PromptAsync(string prompt)
     {
         if (_mcpConfig == null)
         {
             throw new MPCConfigNotFoundException();
         }
-        
-        return await _mcpService.Prompt(_mcpConfig!, [new Message()
+
+        return await _mcpService.Prompt(_mcpConfig, [new Message()
         {
             Content = prompt,
             Role = ServiceConstants.Roles.User,
             Type = MessageType.CloudLLM
-        }]);
+        }], _maxIterations);
     }
 }

--- a/src/MaIN.Core/Hub/Utils/ToolConfigurationBuilder.cs
+++ b/src/MaIN.Core/Hub/Utils/ToolConfigurationBuilder.cs
@@ -3,18 +3,15 @@ using MaIN.Domain.Entities.Tools;
 using MaIN.Domain.Exceptions.Tools;
 
 namespace MaIN.Core.Hub.Utils;
-//TODO try to share logic of adding tool to the list across methods https://github.com/wisedev-code/MaIN.NET/pull/98#discussion_r2454997846
+
 public sealed class ToolsConfigurationBuilder
 {
+    private static readonly JsonSerializerOptions s_deserializeOptions = new() { PropertyNameCaseInsensitive = true };
     private readonly ToolsConfiguration _config = new() { Tools = [] };
 
-    public ToolsConfigurationBuilder AddDefaultTool(
-        string type)
+    public ToolsConfigurationBuilder AddDefaultTool(string type)
     {
-        _config.Tools.Add(new ToolDefinition
-        {
-            Type = type
-        });
+        _config.Tools.Add(new ToolDefinition { Type = type });
         return this;
     }
 
@@ -24,17 +21,7 @@ public sealed class ToolsConfigurationBuilder
         object parameters,
         Func<string, Task<string>> execute)
     {
-        _config.Tools.Add(new ToolDefinition
-        {
-            Function = new FunctionDefinition
-            {
-                Name = name,
-                Description = description,
-                Parameters = parameters
-            },
-            Execute = execute
-        });
-        return this;
+        return AddToolCore(name, description, parameters, execute);
     }
 
     public ToolsConfigurationBuilder AddTool(
@@ -43,17 +30,7 @@ public sealed class ToolsConfigurationBuilder
         object parameters,
         Func<string, string> execute)
     {
-        _config.Tools!.Add(new ToolDefinition
-        {
-            Function = new FunctionDefinition
-            {
-                Name = name,
-                Description = description,
-                Parameters = parameters
-            },
-            Execute = args => Task.FromResult(execute(args))
-        });
-        return this;
+        return AddToolCore(name, description, parameters, args => Task.FromResult(execute(args)));
     }
 
     public ToolsConfigurationBuilder AddTool<TArgs>(
@@ -62,23 +39,11 @@ public sealed class ToolsConfigurationBuilder
         object parameters,
         Func<TArgs, Task<object>> execute) where TArgs : class
     {
-        _config.Tools.Add(new ToolDefinition
-        {
-            Function = new FunctionDefinition
+        return AddToolCore(name, description, parameters, async argsJson =>
             {
-                Name = name,
-                Description = description,
-                Parameters = parameters
-            },
-            Execute = async (argsJson) =>
-            {
-                var args = JsonSerializer.Deserialize<TArgs>(argsJson,
-                    new JsonSerializerOptions { PropertyNameCaseInsensitive = true })!;
-                var result = await execute(args);
-                return JsonSerializer.Serialize(result);
-            }
-        });
-        return this;
+                var args = JsonSerializer.Deserialize<TArgs>(argsJson, s_deserializeOptions)!;
+                return JsonSerializer.Serialize(await execute(args));
+            });
     }
 
     public ToolsConfigurationBuilder AddTool<TArgs>(
@@ -87,23 +52,11 @@ public sealed class ToolsConfigurationBuilder
         object parameters,
         Func<TArgs, object> execute) where TArgs : class
     {
-        _config.Tools!.Add(new ToolDefinition
-        {
-            Function = new FunctionDefinition
+        return AddToolCore(name, description, parameters, argsJson =>
             {
-                Name = name,
-                Description = description,
-                Parameters = parameters
-            },
-            Execute = (argsJson) =>
-            {
-                var args = JsonSerializer.Deserialize<TArgs>(argsJson,
-                    new JsonSerializerOptions { PropertyNameCaseInsensitive = true })!;
-                var result = execute(args);
-                return Task.FromResult(JsonSerializer.Serialize(result));
-            }
-        });
-        return this;
+                var args = JsonSerializer.Deserialize<TArgs>(argsJson, s_deserializeOptions)!;
+                return Task.FromResult(JsonSerializer.Serialize(execute(args)));
+            });
     }
 
     public ToolsConfigurationBuilder AddTool(
@@ -111,41 +64,33 @@ public sealed class ToolsConfigurationBuilder
         string description,
         Func<Task<object>> execute)
     {
-        _config.Tools.Add(new ToolDefinition
-        {
-            Function = new FunctionDefinition
-            {
-                Name = name,
-                Description = description,
-                Parameters = new { type = "object", properties = new { } }
-            },
-            Execute = async (args) =>
-            {
-                var result = await execute();
-                return JsonSerializer.Serialize(result);
-            }
-        });
-        return this;
+        return AddToolCore(
+            name,
+            description,
+            new { type = "object", properties = new { } },
+            async _ => JsonSerializer.Serialize(await execute()));
     }
 
     public ToolsConfigurationBuilder AddTool(
         string name,
         string description,
         Func<object> execute)
+        => AddToolCore(
+            name,
+            description,
+            new { type = "object", properties = new { } },
+            _ => Task.FromResult(JsonSerializer.Serialize(execute())));
+
+    private ToolsConfigurationBuilder AddToolCore(
+        string name,
+        string description,
+        object parameters,
+        Func<string, Task<string>> execute)
     {
         _config.Tools.Add(new ToolDefinition
         {
-            Function = new FunctionDefinition
-            {
-                Name = name,
-                Description = description,
-                Parameters = new { type = "object", properties = new { } }
-            },
-            Execute = (args) =>
-            {
-                var result = execute();
-                return Task.FromResult(JsonSerializer.Serialize(result));
-            }
+            Function = new FunctionDefinition { Name = name, Description = description, Parameters = parameters },
+            Execute = execute
         });
         return this;
     }

--- a/src/MaIN.Core/Hub/Utils/ToolConfigurationBuilder.cs
+++ b/src/MaIN.Core/Hub/Utils/ToolConfigurationBuilder.cs
@@ -103,11 +103,7 @@ public sealed class ToolsConfigurationBuilder
 
     public ToolsConfigurationBuilder WithMaxIterations(int maxIterations)
     {
-        if (maxIterations < 1)
-        {
-            throw new InvalidToolIterationsException(maxIterations);
-        }
-
+        InvalidToolIterationsException.ThrowIfInvalid(maxIterations);
         _config.MaxIterations = maxIterations;
         return this;
     }

--- a/src/MaIN.Core/Hub/Utils/ToolConfigurationBuilder.cs
+++ b/src/MaIN.Core/Hub/Utils/ToolConfigurationBuilder.cs
@@ -1,12 +1,13 @@
 using System.Text.Json;
 using MaIN.Domain.Entities.Tools;
+using MaIN.Domain.Exceptions.Tools;
 
 namespace MaIN.Core.Hub.Utils;
 //TODO try to share logic of adding tool to the list across methods https://github.com/wisedev-code/MaIN.NET/pull/98#discussion_r2454997846
 public sealed class ToolsConfigurationBuilder
 {
     private readonly ToolsConfiguration _config = new() { Tools = [] };
-    
+
     public ToolsConfigurationBuilder AddDefaultTool(
         string type)
     {
@@ -16,10 +17,10 @@ public sealed class ToolsConfigurationBuilder
         });
         return this;
     }
-    
+
     public ToolsConfigurationBuilder AddTool(
-        string name, 
-        string description, 
+        string name,
+        string description,
         object parameters,
         Func<string, Task<string>> execute)
     {
@@ -37,8 +38,8 @@ public sealed class ToolsConfigurationBuilder
     }
 
     public ToolsConfigurationBuilder AddTool(
-        string name, 
-        string description, 
+        string name,
+        string description,
         object parameters,
         Func<string, string> execute)
     {
@@ -56,8 +57,8 @@ public sealed class ToolsConfigurationBuilder
     }
 
     public ToolsConfigurationBuilder AddTool<TArgs>(
-        string name, 
-        string description, 
+        string name,
+        string description,
         object parameters,
         Func<TArgs, Task<object>> execute) where TArgs : class
     {
@@ -71,7 +72,7 @@ public sealed class ToolsConfigurationBuilder
             },
             Execute = async (argsJson) =>
             {
-                var args = JsonSerializer.Deserialize<TArgs>(argsJson, 
+                var args = JsonSerializer.Deserialize<TArgs>(argsJson,
                     new JsonSerializerOptions { PropertyNameCaseInsensitive = true })!;
                 var result = await execute(args);
                 return JsonSerializer.Serialize(result);
@@ -81,8 +82,8 @@ public sealed class ToolsConfigurationBuilder
     }
 
     public ToolsConfigurationBuilder AddTool<TArgs>(
-        string name, 
-        string description, 
+        string name,
+        string description,
         object parameters,
         Func<TArgs, object> execute) where TArgs : class
     {
@@ -96,7 +97,7 @@ public sealed class ToolsConfigurationBuilder
             },
             Execute = (argsJson) =>
             {
-                var args = JsonSerializer.Deserialize<TArgs>(argsJson, 
+                var args = JsonSerializer.Deserialize<TArgs>(argsJson,
                     new JsonSerializerOptions { PropertyNameCaseInsensitive = true })!;
                 var result = execute(args);
                 return Task.FromResult(JsonSerializer.Serialize(result));
@@ -106,7 +107,7 @@ public sealed class ToolsConfigurationBuilder
     }
 
     public ToolsConfigurationBuilder AddTool(
-        string name, 
+        string name,
         string description,
         Func<Task<object>> execute)
     {
@@ -128,7 +129,7 @@ public sealed class ToolsConfigurationBuilder
     }
 
     public ToolsConfigurationBuilder AddTool(
-        string name, 
+        string name,
         string description,
         Func<object> execute)
     {
@@ -152,6 +153,17 @@ public sealed class ToolsConfigurationBuilder
     public ToolsConfigurationBuilder WithToolChoice(string choice)
     {
         _config.ToolChoice = choice;
+        return this;
+    }
+
+    public ToolsConfigurationBuilder WithMaxIterations(int maxIterations)
+    {
+        if (maxIterations < 1)
+        {
+            throw new InvalidToolIterationsException(maxIterations);
+        }
+
+        _config.MaxIterations = maxIterations;
         return this;
     }
 

--- a/src/MaIN.Domain/Entities/Tools/ToolsConfiguration.cs
+++ b/src/MaIN.Domain/Entities/Tools/ToolsConfiguration.cs
@@ -4,7 +4,8 @@ public class ToolsConfiguration
 {
     public required List<ToolDefinition> Tools { get; set; }
     public string? ToolChoice { get; set; }
-    
+    public int? MaxIterations { get; set; }
+
     public Func<string, Task<string>>? GetExecutor(string functionName)
     {
         return Tools.FirstOrDefault(t => t.Function!.Name == functionName)?.Execute;

--- a/src/MaIN.Domain/Exceptions/Tools/InvalidToolIterationsException.cs
+++ b/src/MaIN.Domain/Exceptions/Tools/InvalidToolIterationsException.cs
@@ -1,0 +1,10 @@
+using System.Net;
+
+namespace MaIN.Domain.Exceptions.Tools;
+
+public class InvalidToolIterationsException(int value)
+    : MaINCustomException($"MaxIterations must be at least 1, but received {value}.")
+{
+    public override string PublicErrorMessage => Message;
+    public override HttpStatusCode HttpStatusCode => HttpStatusCode.BadRequest;
+}

--- a/src/MaIN.Domain/Exceptions/Tools/InvalidToolIterationsException.cs
+++ b/src/MaIN.Domain/Exceptions/Tools/InvalidToolIterationsException.cs
@@ -7,4 +7,12 @@ public class InvalidToolIterationsException(int value)
 {
     public override string PublicErrorMessage => Message;
     public override HttpStatusCode HttpStatusCode => HttpStatusCode.BadRequest;
+
+    public static void ThrowIfInvalid(int value)
+    {
+        if (value < 1)
+        {
+            throw new InvalidToolIterationsException(value);
+        }
+    }
 }

--- a/src/MaIN.Services/Services/Abstract/IMcpService.cs
+++ b/src/MaIN.Services/Services/Abstract/IMcpService.cs
@@ -1,9 +1,9 @@
-﻿using MaIN.Domain.Entities;
+using MaIN.Domain.Entities;
 using MaIN.Services.Services.Models;
 
 namespace MaIN.Services.Services.Abstract;
 
 public interface IMcpService
 {
-    Task<McpResult> Prompt(Mcp config, List<Message> messageHistory);
+    Task<McpResult> Prompt(Mcp config, List<Message> messageHistory, int? maxIterations = null);
 }

--- a/src/MaIN.Services/Services/LLMService/AnthropicService.cs
+++ b/src/MaIN.Services/Services/LLMService/AnthropicService.cs
@@ -1,20 +1,20 @@
-﻿using MaIN.Domain.Entities;
+using System.Collections.Concurrent;
+using System.Text;
+using System.Text.Json;
+using LLama.Common;
+using MaIN.Domain.Configuration;
+using MaIN.Domain.Configuration.BackendInferenceParams;
+using MaIN.Domain.Entities;
+using MaIN.Domain.Entities.Tools;
+using MaIN.Domain.Exceptions;
 using MaIN.Domain.Models;
+using MaIN.Domain.Models.Concrete;
 using MaIN.Services.Constants;
 using MaIN.Services.Services.Abstract;
+using MaIN.Services.Services.LLMService.Utils;
 using MaIN.Services.Services.Models;
 using MaIN.Services.Utils;
 using Microsoft.Extensions.Logging;
-using System.Collections.Concurrent;
-using System.Text.Json;
-using System.Text;
-using LLama.Common;
-using MaIN.Domain.Configuration;
-using MaIN.Domain.Entities.Tools;
-using MaIN.Domain.Exceptions;
-using MaIN.Domain.Models.Concrete;
-using MaIN.Services.Services.LLMService.Utils;
-using MaIN.Domain.Configuration.BackendInferenceParams;
 
 namespace MaIN.Services.Services.LLMService;
 
@@ -43,7 +43,9 @@ public sealed class AnthropicService(
         client.DefaultRequestHeaders.Add("anthropic-version", "2023-06-01");
 
         if (requireSkillsBeta)
+        {
             client.DefaultRequestHeaders.Add("anthropic-beta", ServiceConstants.AnthropicBetaFeatures.SkillsBetaHeader);
+        }
 
         return client;
     }
@@ -73,7 +75,9 @@ public sealed class AnthropicService(
         ValidateApiKey();
 
         if (!chat.Messages.Any())
+        {
             return null;
+        }
 
         var lastMessage = chat.Messages.Last();
         await ChatHelper.ExtractImageFromFiles(lastMessage);
@@ -158,8 +162,9 @@ public sealed class AnthropicService(
         StringBuilder fullResponseBuilder = new();
         int iterations = 0;
         List<AnthropicToolUse>? currentToolUses = null;
+        var maxToolIterations = chat.ToolsConfiguration?.MaxIterations ?? MaxToolIterations;
 
-        while (iterations < MaxToolIterations)
+        while (iterations < maxToolIterations)
         {
             if (iterations > 0 && fullResponseBuilder.Length > 0)
             {
@@ -167,7 +172,9 @@ public sealed class AnthropicService(
                 tokens.Add(spaceToken);
 
                 if (options.TokenCallback != null)
+                {
                     await options.TokenCallback(spaceToken);
+                }
 
                 if (options.InteractiveUpdates)
                 {
@@ -291,10 +298,10 @@ public sealed class AnthropicService(
             iterations++;
         }
 
-        if (iterations >= MaxToolIterations)
+        if (iterations >= maxToolIterations)
         {
             logger?.LogWarning("Maximum tool iterations ({MaxIterations}) reached for chat {ChatId}",
-                MaxToolIterations, chat.Id);
+                maxToolIterations, chat.Id);
         }
 
         var finalResponse = fullResponseBuilder.ToString();
@@ -350,9 +357,15 @@ public sealed class AnthropicService(
         while (true)
         {
             var line = await reader.ReadLineAsync(cancellationToken);
-            if (line is null) break;
+            if (line is null)
+            {
+                break;
+            }
+
             if (string.IsNullOrWhiteSpace(line))
+            {
                 continue;
+            }
 
             if (line.StartsWith("event:"))
             {
@@ -392,7 +405,9 @@ public sealed class AnthropicService(
                             resultBuilder.Append(chunk.Delta.Text);
 
                             if (options.TokenCallback != null)
+                            {
                                 await options.TokenCallback(token);
+                            }
 
                             if (options.InteractiveUpdates)
                             {
@@ -429,12 +444,12 @@ public sealed class AnthropicService(
 
         return null;
     }
-    
+
     private async Task HandleApiError(HttpResponseMessage response, CancellationToken cancellationToken = default)
     {
         var errorResponseBody = await response.Content.ReadAsStringAsync(cancellationToken);
         var errorMessage = ExtractApiErrorMessage(errorResponseBody);
-                
+
         throw new LLMApiException(LLMApiRegistry.Anthropic.ApiName, response.StatusCode, errorMessage ?? errorResponseBody);
     }
 
@@ -529,15 +544,28 @@ public sealed class AnthropicService(
 
         if (anthParams != null)
         {
-            if (anthParams.Temperature.HasValue) requestBody["temperature"] = anthParams.Temperature.Value;
-            if (anthParams.TopP.HasValue) requestBody["top_p"] = anthParams.TopP.Value;
-            if (anthParams.TopK.HasValue) requestBody["top_k"] = anthParams.TopK.Value;
+            if (anthParams.Temperature.HasValue)
+            {
+                requestBody["temperature"] = anthParams.Temperature.Value;
+            }
+
+            if (anthParams.TopP.HasValue)
+            {
+                requestBody["top_p"] = anthParams.TopP.Value;
+            }
+
+            if (anthParams.TopK.HasValue)
+            {
+                requestBody["top_k"] = anthParams.TopK.Value;
+            }
         }
 
         if (chat.BackendParams?.AdditionalParams != null)
         {
             foreach (var (key, value) in chat.BackendParams.AdditionalParams)
+            {
                 requestBody[key] = value;
+            }
         }
 
         if (systemMessage != null && systemMessage.Content is string systemContent)
@@ -587,7 +615,9 @@ public sealed class AnthropicService(
         }
 
         if (toolsList.Count > 0)
+        {
             requestBody["tools"] = toolsList;
+        }
 
         return requestBody;
     }
@@ -604,7 +634,7 @@ public sealed class AnthropicService(
         var httpClient = CreateAnthropicHttpClient();
 
         using var response = await httpClient.GetAsync(ModelsUrl);
-        
+
         if (!response.IsSuccessStatusCode)
         {
             await HandleApiError(response);
@@ -683,9 +713,15 @@ public sealed class AnthropicService(
         while (true)
         {
             var line = await reader.ReadLineAsync(cancellationToken);
-            if (line is null) break;
+            if (line is null)
+            {
+                break;
+            }
+
             if (string.IsNullOrWhiteSpace(line))
+            {
                 continue;
+            }
 
             if (line.StartsWith("data:"))
             {
@@ -741,7 +777,7 @@ public sealed class AnthropicService(
         var content = new StringContent(requestJson, Encoding.UTF8, "application/json");
 
         using var response = await httpClient.PostAsync(CompletionsUrl, content, cancellationToken);
-        
+
         if (!response.IsSuccessStatusCode)
         {
             await HandleApiError(response, cancellationToken);

--- a/src/MaIN.Services/Services/LLMService/LLMService.cs
+++ b/src/MaIN.Services/Services/LLMService/LLMService.cs
@@ -1,3 +1,6 @@
+using System.Collections.Concurrent;
+using System.Text;
+using System.Text.Json;
 using LLama;
 using LLama.Batched;
 using LLama.Common;
@@ -5,9 +8,9 @@ using LLama.Native;
 using LLama.Sampling;
 using MaIN.Domain.Configuration;
 using MaIN.Domain.Entities;
+using MaIN.Domain.Entities.Tools;
 using MaIN.Domain.Exceptions;
 using MaIN.Domain.Exceptions.Models;
-using MaIN.Domain.Entities.Tools;
 using MaIN.Domain.Models;
 using MaIN.Domain.Models.Abstract;
 using MaIN.Services.Constants;
@@ -17,9 +20,6 @@ using MaIN.Services.Services.LLMService.Utils;
 using MaIN.Services.Services.Models;
 using MaIN.Services.Utils;
 using Microsoft.KernelMemory;
-using System.Collections.Concurrent;
-using System.Text;
-using System.Text.Json;
 using Grammar = LLama.Sampling.Grammar;
 using LocalInferenceParams = MaIN.Domain.Entities.LocalInferenceParams;
 #pragma warning disable KMEXP00
@@ -57,7 +57,7 @@ public class LLMService : ILLMService
         CancellationToken cancellationToken = default)
     {
         chat.BackendParams ??= new LocalInferenceParams();
-        
+
         if (chat.BackendParams is not LocalInferenceParams)
         {
             throw new InvalidBackendParamsException("Local LLM", nameof(LocalInferenceParams), chat.BackendParams.GetType().Name);
@@ -86,6 +86,7 @@ public class LLMService : ILLMService
         {
             return await ProcessWithToolsAsync(chat, requestOptions, cancellationToken);
         }
+
         var tokens = await ProcessChatRequest(chat, model, lastMsg, requestOptions, cancellationToken);
         lastMsg.MarkProcessed();
         return await CreateChatResult(chat, tokens, requestOptions);
@@ -150,25 +151,30 @@ public class LLMService : ILLMService
                 ModelLoader.RemoveModel(model.FileName);
                 textGenerator.Dispose();
             }
+
             generator._embedder.Dispose();
             generator._embedder._weights.Dispose();
             generator.Dispose();
 
             var ctxBuilder = new StringBuilder();
             foreach (var citation in searchResult.Results.SelectMany(r => r.Partitions))
+            {
                 ctxBuilder.AppendLine(citation.Text);
+            }
 
             var originalContent = userMessage.Content;
             if (ctxBuilder.Length > 0)
+            {
                 userMessage.Content =
                     $"Use the following context to answer the question:\n\n{ctxBuilder}\n\nQuestion: {originalContent}";
+            }
+
             userMessage.Files = null;
 
             var chatResult = await Send(chat, requestOptions, cancellationToken);
             userMessage.Content = originalContent;
             return chatResult;
         }
-
 
         MemoryAnswer result;
 
@@ -574,7 +580,9 @@ public class LLMService : ILLMService
     {
         // Try registry lookup (TryGetById to avoid throwing for unregistered models)
         if (ModelRegistry.TryGetById(chat.ModelId, out var model) && model is LocalModel localModel)
+        {
             return localModel;
+        }
 
         // 3. Fallback: create generic local model for unregistered models
         var modelId = chat.ModelId;
@@ -592,8 +600,11 @@ public class LLMService : ILLMService
             // Model name only — replace ':' with '-' (colon is illegal in Windows file names)
             fileName = modelId.Replace(':', '-');
             if (!fileName.EndsWith(".gguf", StringComparison.OrdinalIgnoreCase))
+            {
                 fileName += ".gguf";
+            }
         }
+
         return new GenericLocalModel(FileName: fileName);
     }
 
@@ -613,7 +624,10 @@ public class LLMService : ILLMService
     private string ResolvePath(string? customPath, string fileName)
     {
         if (Path.IsPathFullyQualified(fileName))
+        {
             return fileName;
+        }
+
         return Path.Combine(customPath ?? modelsPath, fileName);
     }
 
@@ -667,8 +681,9 @@ public class LLMService : ILLMService
         var iterations = 0;
         var lastResponseTokens = new List<LLMTokenValue>();
         var lastResponse = string.Empty;
+        var maxToolIterations = chat.ToolsConfiguration?.MaxIterations ?? MaxToolIterations;
 
-        while (iterations < MaxToolIterations)
+        while (iterations < maxToolIterations)
         {
             var lastMsg = chat.Messages.Last();
             var tokenCallbackOrg = requestOptions.TokenCallback;
@@ -797,7 +812,7 @@ public class LLMService : ILLMService
             iterations++;
         }
 
-        if (iterations >= MaxToolIterations)
+        if (iterations >= maxToolIterations)
         {
             var errorMessage = "Maximum tool invocation iterations reached. Ending the tool-loop prematurely.";
             var iterationMessage = new Message
@@ -834,5 +849,4 @@ public class LLMService : ILLMService
             ? $"{message.Content}{additionalPrompt}"
             : message.Content;
     }
-
 }

--- a/src/MaIN.Services/Services/LLMService/OpenAiCompatibleService.cs
+++ b/src/MaIN.Services/Services/LLMService/OpenAiCompatibleService.cs
@@ -1,22 +1,22 @@
-﻿using MaIN.Domain.Models;
-using MaIN.Services.Constants;
-using MaIN.Services.Services.Abstract;
-using MaIN.Services.Services.LLMService.Utils;
-using MaIN.Services.Services.Models;
-using MaIN.Services.Utils;
-using Microsoft.Extensions.Logging;
-using Microsoft.KernelMemory;
 using System.Collections.Concurrent;
 using System.Net.Http.Headers;
 using System.Net.Mime;
 using System.Text;
 using System.Text.Json;
 using System.Text.Json.Serialization;
-using MaIN.Domain.Entities;
-using MaIN.Services.Services.LLMService.Memory;
 using LLama.Common;
+using MaIN.Domain.Entities;
 using MaIN.Domain.Entities.Tools;
 using MaIN.Domain.Exceptions;
+using MaIN.Domain.Models;
+using MaIN.Services.Constants;
+using MaIN.Services.Services.Abstract;
+using MaIN.Services.Services.LLMService.Memory;
+using MaIN.Services.Services.LLMService.Utils;
+using MaIN.Services.Services.Models;
+using MaIN.Services.Utils;
+using Microsoft.Extensions.Logging;
+using Microsoft.KernelMemory;
 
 namespace MaIN.Services.Services.LLMService;
 
@@ -36,7 +36,6 @@ public abstract class OpenAiCompatibleService(
 
     private static readonly JsonSerializerOptions DefaultJsonSerializerOptions = new() { PropertyNameCaseInsensitive = true };
 
-
     protected abstract string GetApiKey();
     protected abstract string GetApiName();
     protected abstract void ValidateApiKey();
@@ -51,14 +50,16 @@ public abstract class OpenAiCompatibleService(
         ChatRequestOptions options,
         CancellationToken cancellationToken = default)
     {
-        if (chat.BackendParams != null && chat.BackendParams?.GetType() != ExpectedParamsType)
+        if (chat.BackendParams is not null && chat.BackendParams?.GetType() != ExpectedParamsType)
         {
             throw new InvalidBackendParamsException(GetApiName(), ExpectedParamsType.Name, chat.BackendParams!.GetType().Name);
         }
 
         ValidateApiKey();
         if (!chat.Messages.Any())
+        {
             return null;
+        }
 
         List<LLMTokenValue> tokens = new();
         string apiKey = GetApiKey();
@@ -78,7 +79,7 @@ public abstract class OpenAiCompatibleService(
             return CreateChatResult(chat, resultBuilder.ToString(), memoryResult.Message.Tokens);
         }
 
-        if (chat.ToolsConfiguration?.Tools != null && chat.ToolsConfiguration.Tools.Any())
+        if (chat.ToolsConfiguration?.Tools is not null && chat.ToolsConfiguration.Tools.Any())
         {
             return await ProcessWithToolsAsync(
                 chat,
@@ -89,7 +90,7 @@ public abstract class OpenAiCompatibleService(
                 cancellationToken);
         }
 
-        if (options.InteractiveUpdates || options.TokenCallback != null)
+        if (options.InteractiveUpdates || options.TokenCallback is not null)
         {
             await ProcessStreamingChatAsync(
                 chat,
@@ -135,26 +136,29 @@ public abstract class OpenAiCompatibleService(
         CancellationToken cancellationToken)
     {
         StringBuilder resultBuilder = new();
-        StringBuilder fullResponseBuilder = new();  
+        StringBuilder fullResponseBuilder = new();
         int iterations = 0;
+        var maxToolIterations = chat.ToolsConfiguration?.MaxIterations ?? MaxToolIterations;
 
-        while (iterations < MaxToolIterations)
+        while (iterations < maxToolIterations)
         {
             if (iterations > 0 && options.InteractiveUpdates && fullResponseBuilder.Length > 0)
             {
                 var spaceToken = new LLMTokenValue { Text = " ", Type = TokenType.Message };
                 tokens.Add(spaceToken);
-                
-                if (options.TokenCallback != null)
+
+                if (options.TokenCallback is not null)
+                {
                     await options.TokenCallback(spaceToken);
-                    
+                }
+
                 await _notificationService.DispatchNotification(
                     NotificationMessageBuilder.CreateChatCompletion(chat.Id, spaceToken, false),
                     ServiceConstants.Notifications.ReceiveMessageUpdate);
             }
 
             List<ToolCall>? currentToolCalls;
-            if (options.InteractiveUpdates || options.TokenCallback != null)
+            if (options.InteractiveUpdates || options.TokenCallback is not null)
             {
                 currentToolCalls = await ProcessStreamingChatWithToolsAsync(
                     chat,
@@ -175,17 +179,18 @@ public abstract class OpenAiCompatibleService(
                     options,
                     cancellationToken);
             }
-            
-            if (resultBuilder.Length > 0) 
+
+            if (resultBuilder.Length > 0)
             {
                 if (fullResponseBuilder.Length > 0)
                 {
-                    fullResponseBuilder.Append(" ");
+                    fullResponseBuilder.Append(' ');
                 }
+
                 fullResponseBuilder.Append(resultBuilder);
             }
-            
-            if (currentToolCalls == null || !currentToolCalls.Any())
+
+            if (currentToolCalls is null || currentToolCalls.Count == 0)
             {
                 break;
             }
@@ -208,7 +213,7 @@ public abstract class OpenAiCompatibleService(
 
                 var executor = chat.ToolsConfiguration?.GetExecutor(toolCall.Function.Name);
 
-                if (executor == null)
+                if (executor is null)
                 {
                     var errorMessage = $"No executor found for tool: {toolCall.Function.Name}";
                     logger?.LogError(errorMessage);
@@ -240,7 +245,7 @@ public abstract class OpenAiCompatibleService(
                 catch (Exception ex)
                 {
                     logger?.LogError(ex, "Error executing tool {ToolName}", toolCall.Function.Name);
-                    
+
                     var errorResult = JsonSerializer.Serialize(new { error = ex.Message });
                     var toolMessage = new ChatMessage(ServiceConstants.Roles.Tool, errorResult)
                     {
@@ -255,10 +260,10 @@ public abstract class OpenAiCompatibleService(
             iterations++;
         }
 
-        if (iterations >= MaxToolIterations)
+        if (iterations >= maxToolIterations)
         {
-            logger?.LogWarning("Maximum tool iterations ({MaxIterations}) reached for chat {ChatId}", 
-                MaxToolIterations, chat.Id);
+            logger?.LogWarning("Maximum tool iterations ({MaxIterations}) reached for chat {ChatId}",
+                maxToolIterations, chat.Id);
         }
 
         var finalResponse = fullResponseBuilder.ToString();
@@ -317,15 +322,23 @@ public abstract class OpenAiCompatibleService(
         while (true)
         {
             var line = await reader.ReadLineAsync(cancellationToken);
-            if (line is null) break;
+            if (line is null)
+            {
+                break;
+            }
+
             if (string.IsNullOrWhiteSpace(line))
+            {
                 continue;
+            }
 
             if (line.StartsWith("data: "))
             {
                 var data = line.Substring("data: ".Length).Trim();
                 if (data == "[DONE]")
+                {
                     break;
+                }
 
                 try
                 {
@@ -333,7 +346,7 @@ public abstract class OpenAiCompatibleService(
                         new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
 
                     var choice = chunk?.Choices?.FirstOrDefault();
-                    if (choice?.Delta != null)
+                    if (choice?.Delta is not null)
                     {
                         // Handle content
                         if (!string.IsNullOrEmpty(choice.Delta.Content))
@@ -356,7 +369,7 @@ public abstract class OpenAiCompatibleService(
                             }
                         }
 
-                        if (choice.Delta.ToolCalls != null)
+                        if (choice.Delta.ToolCalls is not null)
                         {
                             foreach (var toolCallChunk in choice.Delta.ToolCalls)
                             {
@@ -368,18 +381,26 @@ public abstract class OpenAiCompatibleService(
                                 var builder = toolCallsBuilder[toolCallChunk.Index];
 
                                 if (!string.IsNullOrEmpty(toolCallChunk.Id))
+                                {
                                     builder.Id = toolCallChunk.Id;
+                                }
 
                                 if (!string.IsNullOrEmpty(toolCallChunk.Type))
+                                {
                                     builder.Type = toolCallChunk.Type;
+                                }
 
-                                if (toolCallChunk.Function != null)
+                                if (toolCallChunk.Function is not null)
                                 {
                                     if (!string.IsNullOrEmpty(toolCallChunk.Function.Name))
+                                    {
                                         builder.FunctionName = toolCallChunk.Function.Name;
+                                    }
 
                                     if (!string.IsNullOrEmpty(toolCallChunk.Function.Arguments))
+                                    {
                                         builder.FunctionArguments.Append(toolCallChunk.Function.Arguments);
+                                    }
                                 }
                             }
                         }
@@ -393,9 +414,9 @@ public abstract class OpenAiCompatibleService(
         }
 
         // Build final tool calls from accumulated chunks
-        if (toolCallsBuilder.Any())
+        if (toolCallsBuilder.Count != 0)
         {
-            return toolCallsBuilder.Values.Select(b => b.Build()).ToList();
+            return [.. toolCallsBuilder.Values.Select(b => b.Build())];
         }
 
         return null;
@@ -418,7 +439,7 @@ public abstract class OpenAiCompatibleService(
         var content = new StringContent(requestJson, Encoding.UTF8, MediaTypeNames.Application.Json);
 
         using var response = await client.PostAsync(ChatCompletionsUrl, content, cancellationToken);
-        
+
         if (!response.IsSuccessStatusCode)
         {
             await HandleApiError(response, cancellationToken);
@@ -430,7 +451,7 @@ public abstract class OpenAiCompatibleService(
 
         var message = chatResponse?.Choices?.FirstOrDefault()?.Message;
 
-        if (message?.Content != null)
+        if (message?.Content is not null)
         {
             resultBuilder.Append(message.Content);
         }
@@ -444,8 +465,10 @@ public abstract class OpenAiCompatibleService(
         ChatRequestOptions requestOptions,
         CancellationToken cancellationToken = default)
     {
-        if (!chat.Messages.Any())
+        if (chat.Messages.Count == 0)
+        {
             return null;
+        }
 
         var kernel = memoryFactory.CreateMemoryWithOpenAi(GetApiKey(), chat.MemoryParams);
         await memoryService.ImportDataToMemory((kernel, null), memoryOptions, cancellationToken);
@@ -453,7 +476,7 @@ public abstract class OpenAiCompatibleService(
         var lastMessage = chat.Messages.Last();
         var userQuery = lastMessage.Content;
 
-        if (chat.MemoryParams.Grammar != null)
+        if (chat.MemoryParams.Grammar is not null)
         {
             var jsonGrammarConverter = new GrammarToJsonConverter();
             var jsonGrammar = jsonGrammarConverter.ConvertToJson(chat.MemoryParams.Grammar);
@@ -496,7 +519,7 @@ public abstract class OpenAiCompatibleService(
             var tokens = new List<LLMTokenValue>();
             var resultBuilder = new StringBuilder();
 
-            if (requestOptions.InteractiveUpdates || requestOptions.TokenCallback != null)
+            if (requestOptions.InteractiveUpdates || requestOptions.TokenCallback is not null)
             {
                 await ProcessStreamingChatAsync(chat, conversation, GetApiKey(), tokens, resultBuilder, requestOptions, cancellationToken);
             }
@@ -522,7 +545,7 @@ public abstract class OpenAiCompatibleService(
         MemoryAnswer retrievedContext;
         var standardTokens = new List<LLMTokenValue>();
 
-        if (requestOptions.InteractiveUpdates || requestOptions.TokenCallback != null)
+        if (requestOptions.InteractiveUpdates || requestOptions.TokenCallback is not null)
         {
             var responseBuilder = new StringBuilder();
 
@@ -594,10 +617,15 @@ public abstract class OpenAiCompatibleService(
                     var contextBuilder = new StringBuilder();
                     foreach (var partition in retrievedChunks.OrderByDescending(p => p.Relevance))
                     {
-                        if (string.IsNullOrWhiteSpace(partition.Text)) continue;
+                        if (string.IsNullOrWhiteSpace(partition.Text))
+                        {
+                            continue;
+                        }
+
                         contextBuilder.AppendLine(partition.Text);
                         contextBuilder.AppendLine();
                     }
+
                     var fallback = contextBuilder.ToString().TrimEnd();
 
                     logger?.LogInformation(
@@ -626,20 +654,20 @@ public abstract class OpenAiCompatibleService(
         SetAuthorizationIfNeeded(client, GetApiKey());
 
         using var response = await client.GetAsync(ModelsUrl);
-        
+
         if (!response.IsSuccessStatusCode)
         {
             await HandleApiError(response);
         }
 
         var responseJson = await response.Content.ReadAsStringAsync();
-        var modelsResponse = JsonSerializer.Deserialize<OpenAiModelsResponse>(responseJson, 
+        var modelsResponse = JsonSerializer.Deserialize<OpenAiModelsResponse>(responseJson,
             new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
 
         return (modelsResponse?.Data?
                     .Select(m => m.Id)
-                    .Where(id => id != null)
-                    .ToArray() 
+                    .Where(id => id is not null)
+                    .ToArray()
                 ?? [])!;
     }
 
@@ -675,27 +703,31 @@ public abstract class OpenAiCompatibleService(
 
     protected static async Task ExtractImageFromFiles(Message message)
     {
-        if (message.Files == null || message.Files.Count == 0)
+        if (message.Files is null || message.Files.Count == 0)
+        {
             return;
+        }
 
         var imageFiles = message.Files
             .Where(f => ImageExtensions.Contains(f.Extension.ToLowerInvariant()))
             .ToList();
 
         if (imageFiles.Count == 0)
+        {
             return;
+        }
 
         var imageBytesList = new List<byte[]>();
         foreach (var imageFile in imageFiles)
         {
-            if (imageFile.StreamContent != null)
+            if (imageFile.StreamContent is not null)
             {
                 using var ms = new MemoryStream();
                 imageFile.StreamContent.Position = 0;
                 await imageFile.StreamContent.CopyToAsync(ms);
                 imageBytesList.Add(ms.ToArray());
             }
-            else if (imageFile.Path != null)
+            else if (imageFile.Path is not null)
             {
                 imageBytesList.Add(await File.ReadAllBytesAsync(imageFile.Path));
             }
@@ -706,12 +738,14 @@ public abstract class OpenAiCompatibleService(
         message.Images = imageBytesList;
 
         if (message.Files.Count == 0)
+        {
             message.Files = null;
+        }
     }
 
     protected static bool HasFiles(Message message)
     {
-        return message.Files != null && message.Files.Count > 0;
+        return message.Files is not null && message.Files.Count > 0;
     }
 
     private static void SetAuthorizationIfNeeded(HttpClient client, string apiKey)
@@ -734,7 +768,7 @@ public abstract class OpenAiCompatibleService(
         SetAuthorizationIfNeeded(client, apiKey);
 
         var requestBody = BuildRequestBody(chat, conversation, true);
-        
+
         var requestJson = JsonSerializer.Serialize(requestBody);
         var content = new StringContent(requestJson, Encoding.UTF8, MediaTypeNames.Application.Json);
 
@@ -761,15 +795,23 @@ public abstract class OpenAiCompatibleService(
             cancellationToken.ThrowIfCancellationRequested();
 
             var line = await reader.ReadLineAsync(cancellationToken);
-            if (line is null) break;
+            if (line is null)
+            {
+                break;
+            }
+
             if (string.IsNullOrWhiteSpace(line))
+            {
                 continue;
+            }
 
             if (line.StartsWith("data: "))
             {
                 var data = line.Substring("data: ".Length).Trim();
                 if (data == "[DONE]")
+                {
                     break;
+                }
 
                 try
                 {
@@ -805,7 +847,7 @@ public abstract class OpenAiCompatibleService(
     {
         var errorResponseBody = await response.Content.ReadAsStringAsync(cancellationToken);
         var errorMessage = ExtractApiErrorMessage(errorResponseBody);
-        
+
         throw new LLMApiException(GetApiName(), response.StatusCode, errorMessage ?? errorResponseBody);
     }
 
@@ -814,7 +856,7 @@ public abstract class OpenAiCompatibleService(
         try
         {
             using var jasonDocument = JsonDocument.Parse(json);
-            
+
             if (jasonDocument.RootElement.ValueKind == JsonValueKind.Array)
             {
                 var firstElement = jasonDocument.RootElement[0];
@@ -836,7 +878,7 @@ public abstract class OpenAiCompatibleService(
             // we fall back to the raw response body in the calling method.
             return null;
         }
-        
+
         return null;
     }
 
@@ -869,7 +911,7 @@ public abstract class OpenAiCompatibleService(
         var content = new StringContent(requestJson, Encoding.UTF8, MediaTypeNames.Application.Json);
 
         using var response = await client.PostAsync(ChatCompletionsUrl, content, cancellationToken);
-        
+
         if (!response.IsSuccessStatusCode)
         {
             await HandleApiError(response, cancellationToken);
@@ -880,7 +922,7 @@ public abstract class OpenAiCompatibleService(
             JsonSerializer.Deserialize<ChatCompletionResponse>(responseJson, DefaultJsonSerializerOptions);
         var responseContent = chatResponse?.Choices?.FirstOrDefault()?.Message?.Content;
 
-        if (responseContent != null)
+        if (responseContent is not null)
         {
             resultBuilder.Append(responseContent);
         }
@@ -898,12 +940,12 @@ public abstract class OpenAiCompatibleService(
         ApplyBackendParams(requestBody, chat);
         ApplyAdditionalParams(requestBody, chat);
 
-        if (chat.ToolsConfiguration?.Tools != null && chat.ToolsConfiguration.Tools.Any())
+        if (chat.ToolsConfiguration?.Tools is not null && chat.ToolsConfiguration.Tools.Any())
         {
             requestBody["tools"] = chat.ToolsConfiguration.Tools.Select(t => new
             {
                 type = t.Type,
-                function = t.Function != null ? new
+                function = t.Function is not null ? new
                 {
                     name = t.Function.Name,
                     description = t.Function.Description,
@@ -926,13 +968,16 @@ public abstract class OpenAiCompatibleService(
 
     private static void ApplyAdditionalParams(Dictionary<string, object> requestBody, Chat chat)
     {
-        if (chat.BackendParams?.AdditionalParams == null) return;
+        if (chat.BackendParams?.AdditionalParams is null)
+        {
+            return;
+        }
+
         foreach (var (key, value) in chat.BackendParams.AdditionalParams)
         {
             requestBody[key] = value;
         }
     }
-
 
     protected static ChatResult CreateChatResult(Chat chat, string content, List<LLMTokenValue> tokens)
     {
@@ -953,7 +998,7 @@ public abstract class OpenAiCompatibleService(
 
     private static async Task InvokeTokenCallbackAsync(Func<LLMTokenValue, Task>? callback, LLMTokenValue token)
     {
-        if (callback != null)
+        if (callback is not null)
         {
             await callback.Invoke(token);
         }
@@ -1034,7 +1079,7 @@ file class ChoiceChunk
 file class Delta
 {
     public string? Content { get; set; }
-    
+
     [JsonPropertyName("tool_calls")]
     public List<ToolCallChunk>? ToolCalls { get; set; }
 }
@@ -1054,7 +1099,7 @@ file class FunctionCallChunk
 }
 
 file class OpenAiModelsResponse
-{ 
+{
     public List<OpenAiModel>? Data { get; set; }
 }
 

--- a/src/MaIN.Services/Services/LLMService/OpenAiService.cs
+++ b/src/MaIN.Services/Services/LLMService/OpenAiService.cs
@@ -250,7 +250,7 @@ public sealed class OpenAiService(
         string apiKey,
         CancellationToken cancellationToken)
     {
-        var maxIterations = chat.ToolsConfiguration?.MaxIterations ?? 5;
+        var maxIterations = chat.ToolsConfiguration?.MaxIterations ?? MaxToolIterations;
         string responseJson = string.Empty;
 
         for (var iteration = 0; iteration < maxIterations; iteration++)

--- a/src/MaIN.Services/Services/LLMService/OpenAiService.cs
+++ b/src/MaIN.Services/Services/LLMService/OpenAiService.cs
@@ -250,7 +250,7 @@ public sealed class OpenAiService(
         string apiKey,
         CancellationToken cancellationToken)
     {
-        const int maxIterations = 5;
+        var maxIterations = chat.ToolsConfiguration?.MaxIterations ?? 5;
         string responseJson = string.Empty;
 
         for (var iteration = 0; iteration < maxIterations; iteration++)

--- a/src/MaIN.Services/Services/McpService.cs
+++ b/src/MaIN.Services/Services/McpService.cs
@@ -37,6 +37,8 @@ public class McpService(MaINSettings settings, IServiceProvider serviceProvider,
 
         return backendType switch
         {
+            BackendType.Gemini or BackendType.Vertex when maxIterations.HasValue =>
+                throw new NotSupportedException($"MaxIterations is not supported for {backendType} backend."),
             BackendType.Gemini or BackendType.Vertex =>
                 await PromptWithSK(mcpClient, tools, config, messageHistory, backendType),
             BackendType.Anthropic =>

--- a/src/MaIN.Services/Services/McpService.cs
+++ b/src/MaIN.Services/Services/McpService.cs
@@ -8,6 +8,7 @@ using MaIN.Services.Services.Abstract;
 using MaIN.Services.Services.LLMService.Auth;
 using MaIN.Services.Services.Models;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 using Microsoft.SemanticKernel;
 using Microsoft.SemanticKernel.ChatCompletion;
 using Microsoft.SemanticKernel.Connectors.Google;
@@ -17,7 +18,7 @@ using ModelContextProtocol.Client;
 
 namespace MaIN.Services.Services;
 
-public class McpService(MaINSettings settings, IServiceProvider serviceProvider) : IMcpService
+public class McpService(MaINSettings settings, IServiceProvider serviceProvider, ILogger<McpService>? logger = null) : IMcpService
 {
     public async Task<McpResult> Prompt(Mcp config, List<Message> messageHistory, int? maxIterations = null)
     {
@@ -122,7 +123,7 @@ public class McpService(MaINSettings settings, IServiceProvider serviceProvider)
                     continue;
                 }
 
-                return BuildResult(content, config.Model);
+                return McpService.BuildResult(content, config.Model);
             }
 
             // Add assistant message with tool calls (preserve raw JSON element)
@@ -141,28 +142,7 @@ public class McpService(MaINSettings settings, IServiceProvider serviceProvider)
                 var argsJson = toolCall.GetProperty("function").GetProperty("arguments").GetString() ?? "{}";
                 var toolCallId = toolCall.GetProperty("id").GetString()!;
 
-                var argsDict = JsonSerializer
-                    .Deserialize<Dictionary<string, JsonElement>>(argsJson)
-                    ?.ToDictionary(
-                        kvp => kvp.Key,
-                        kvp => (object?)(kvp.Value.ValueKind switch
-                        {
-                            JsonValueKind.String => (object)kvp.Value.GetString()!,
-                            JsonValueKind.True => true,
-                            JsonValueKind.False => false,
-                            JsonValueKind.Number when kvp.Value.TryGetInt64(out var l) => l,
-                            JsonValueKind.Number => (object)kvp.Value.GetDouble(),
-                            _ => (object)kvp.Value
-                        }))
-                    ?? new Dictionary<string, object?>();
-
-                var toolResult = await mcpClient.CallToolAsync(toolName, argsDict);
-                var resultText = string.Join("\n", toolResult.Content
-                    .Where(c => c.Text != null)
-                    .Select(c => c.Text!));
-
-                if (toolResult.IsError == true)
-                    Console.WriteLine($"[MCP] Tool '{toolName}' returned error: {resultText}");
+                var resultText = await ExecuteToolAsync(mcpClient, toolName, argsJson);
 
                 messages.Add(new Dictionary<string, object>
                 {
@@ -173,7 +153,28 @@ public class McpService(MaINSettings settings, IServiceProvider serviceProvider)
             }
         }
 
-        return BuildResult("Max tool iterations reached.", config.Model);
+        logger?.LogWarning("Max tool iterations ({MaxIterations}) reached. Sending final synthesis request.", effectiveMaxIterations);
+
+        var finalRequestBody = new Dictionary<string, object>
+        {
+            ["model"] = config.Model,
+            ["messages"] = messages,
+            ["tools"] = toolDefs
+        };
+
+        var finalJson = JsonSerializer.Serialize(finalRequestBody);
+        var finalResponse = await client.PostAsync(url,
+            new StringContent(finalJson, Encoding.UTF8, "application/json"));
+        finalResponse.EnsureSuccessStatusCode();
+
+        var finalResponseText = await finalResponse.Content.ReadAsStringAsync();
+        var finalDoc = JsonDocument.Parse(finalResponseText);
+        var finalMessage = finalDoc.RootElement
+            .GetProperty("choices")[0]
+            .GetProperty("message");
+        var finalContent = finalMessage.TryGetProperty("content", out var fc) ? fc.GetString() ?? "" : "";
+
+        return McpService.BuildResult(finalContent, config.Model);
     }
 
     // Anthropic uses a different protocol: x-api-key header, input_schema instead of parameters,
@@ -224,8 +225,10 @@ public class McpService(MaINSettings settings, IServiceProvider serviceProvider)
                     ? (object)new Dictionary<string, object> { ["type"] = "any" }
                     : new Dictionary<string, object> { ["type"] = "auto" }
             };
-            if (systemContent != null)
+            if (systemContent is not null)
+            {
                 requestBody["system"] = systemContent;
+            }
 
             var json = JsonSerializer.Serialize(requestBody);
             var response = await client.PostAsync("https://api.anthropic.com/v1/messages",
@@ -263,14 +266,18 @@ public class McpService(MaINSettings settings, IServiceProvider serviceProvider)
                     continue;
                 }
 
-                return BuildResult(textContent, config.Model);
+                return McpService.BuildResult(textContent, config.Model);
             }
 
             // Add assistant turn with tool_use blocks
             var assistantContent = new List<object>();
             if (!string.IsNullOrEmpty(textContent))
+            {
                 assistantContent.Add(new Dictionary<string, object> { ["type"] = "text", ["text"] = textContent });
+            }
+
             foreach (var tu in toolUses)
+            {
                 assistantContent.Add(new Dictionary<string, object>
                 {
                     ["type"] = "tool_use",
@@ -278,6 +285,8 @@ public class McpService(MaINSettings settings, IServiceProvider serviceProvider)
                     ["name"] = tu.GetProperty("name").GetString()!,
                     ["input"] = tu.GetProperty("input")
                 });
+            }
+
             messages.Add(new Dictionary<string, object> { ["role"] = "assistant", ["content"] = assistantContent });
 
             // Execute tools and collect tool_result blocks
@@ -286,30 +295,7 @@ public class McpService(MaINSettings settings, IServiceProvider serviceProvider)
             {
                 var toolName = tu.GetProperty("name").GetString()!;
                 var toolId = tu.GetProperty("id").GetString()!;
-                var inputElement = tu.GetProperty("input");
-
-                var argsDict = JsonSerializer
-                    .Deserialize<Dictionary<string, JsonElement>>(inputElement.GetRawText())
-                    ?.ToDictionary(
-                        kvp => kvp.Key,
-                        kvp => (object?)(kvp.Value.ValueKind switch
-                        {
-                            JsonValueKind.String => (object)kvp.Value.GetString()!,
-                            JsonValueKind.True => true,
-                            JsonValueKind.False => false,
-                            JsonValueKind.Number when kvp.Value.TryGetInt64(out var l) => l,
-                            JsonValueKind.Number => (object)kvp.Value.GetDouble(),
-                            _ => (object)kvp.Value
-                        }))
-                    ?? new Dictionary<string, object?>();
-
-                var toolResult = await mcpClient.CallToolAsync(toolName, argsDict);
-                var resultText = string.Join("\n", toolResult.Content
-                    .Where(c => c.Text != null)
-                    .Select(c => c.Text!));
-
-                if (toolResult.IsError == true)
-                    Console.WriteLine($"[MCP] Tool '{toolName}' returned error: {resultText}");
+                var resultText = await ExecuteToolAsync(mcpClient, toolName, tu.GetProperty("input").GetRawText());
 
                 toolResults.Add(new Dictionary<string, object>
                 {
@@ -322,7 +308,34 @@ public class McpService(MaINSettings settings, IServiceProvider serviceProvider)
             messages.Add(new Dictionary<string, object> { ["role"] = "user", ["content"] = toolResults });
         }
 
-        return BuildResult("Max tool iterations reached.", config.Model);
+        logger?.LogWarning("Max tool iterations ({MaxIterations}) reached. Sending final synthesis request.", effectiveMaxIterations);
+
+        var finalRequestBody = new Dictionary<string, object>
+        {
+            ["model"] = config.Model,
+            ["max_tokens"] = 4096,
+            ["messages"] = messages,
+            ["tools"] = toolDefs
+        };
+        if (systemContent is not null)
+        {
+            finalRequestBody["system"] = systemContent;
+        }
+
+        var finalJson = JsonSerializer.Serialize(finalRequestBody);
+        var finalResponse = await client.PostAsync("https://api.anthropic.com/v1/messages",
+            new StringContent(finalJson, Encoding.UTF8, "application/json"));
+        finalResponse.EnsureSuccessStatusCode();
+
+        var finalResponseText = await finalResponse.Content.ReadAsStringAsync();
+        var finalDoc = JsonDocument.Parse(finalResponseText);
+        var finalContent = string.Concat(finalDoc.RootElement
+            .GetProperty("content")
+            .EnumerateArray()
+            .Where(b => b.TryGetProperty("type", out var t) && t.GetString() == "text")
+            .Select(b => b.TryGetProperty("text", out var txt) ? txt.GetString() ?? "" : ""));
+
+        return McpService.BuildResult(finalContent, config.Model);
     }
 
     private (string url, string apiKey) GetEndpointAndKey(BackendType backendType, Mcp config)
@@ -371,7 +384,7 @@ public class McpService(MaINSettings settings, IServiceProvider serviceProvider)
         var chatService = kernel.GetRequiredService<IChatCompletionService>();
         var result = await chatService.GetChatMessageContentsAsync(chatHistory, promptSettings, kernel);
 
-        return BuildResult(result.Last().Content!, config.Model);
+        return McpService.BuildResult(result.Last().Content!, config.Model);
     }
 
     private PromptExecutionSettings InitializeGoogleChatCompletions(IKernelBuilder kernelBuilder, Mcp config, BackendType backendType)
@@ -412,7 +425,37 @@ public class McpService(MaINSettings settings, IServiceProvider serviceProvider)
         };
     }
 
-    private McpResult BuildResult(string content, string model) => new()
+    private static Dictionary<string, object?> DeserializeToolArgs(string argsJson)
+    {
+        return JsonSerializer.Deserialize<Dictionary<string, JsonElement>>(argsJson)
+            ?.ToDictionary(
+                kvp => kvp.Key,
+                kvp => (object?)(kvp.Value.ValueKind switch
+                {
+                    JsonValueKind.String => (object)kvp.Value.GetString()!,
+                    JsonValueKind.True => true,
+                    JsonValueKind.False => false,
+                    JsonValueKind.Number when kvp.Value.TryGetInt64(out var l) => l,
+                    JsonValueKind.Number => (object)kvp.Value.GetDouble(),
+                    _ => (object)kvp.Value
+                }))
+            ?? [];
+    }
+
+    private async Task<string> ExecuteToolAsync(IMcpClient mcpClient, string toolName, string argsJson)
+    {
+        var argsDict = DeserializeToolArgs(argsJson);
+        var result = await mcpClient.CallToolAsync(toolName, argsDict);
+        var text = string.Join("\n", result.Content.Where(c => c.Text is not null).Select(c => c.Text!));
+        if (result.IsError == true)
+        {
+            logger?.LogError("MCP tool '{ToolName}' returned error: {Error}", toolName, text);
+        }
+
+        return text;
+    }
+
+    private static McpResult BuildResult(string content, string model) => new()
     {
         CreatedAt = DateTime.Now,
         Message = new Message

--- a/src/MaIN.Services/Services/McpService.cs
+++ b/src/MaIN.Services/Services/McpService.cs
@@ -1,27 +1,25 @@
+using System.Net.Http.Headers;
+using System.Text;
+using System.Text.Json;
 using MaIN.Domain.Configuration;
 using MaIN.Domain.Entities;
 using MaIN.Domain.Models.Concrete;
 using MaIN.Services.Services.Abstract;
 using MaIN.Services.Services.LLMService.Auth;
-using MaIN.Services.Services.LLMService.Utils;
 using MaIN.Services.Services.Models;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.SemanticKernel;
 using Microsoft.SemanticKernel.ChatCompletion;
 using Microsoft.SemanticKernel.Connectors.Google;
 using ModelContextProtocol.Client;
-using System.Net.Http.Headers;
-using System.Text;
-using System.Text.Json;
 
 #pragma warning disable SKEXP0001
-#pragma warning disable SKEXP0070
 
 namespace MaIN.Services.Services;
 
 public class McpService(MaINSettings settings, IServiceProvider serviceProvider) : IMcpService
 {
-    public async Task<McpResult> Prompt(Mcp config, List<Message> messageHistory)
+    public async Task<McpResult> Prompt(Mcp config, List<Message> messageHistory, int? maxIterations = null)
     {
         await using var mcpClient = await McpClientFactory.CreateAsync(
             new StdioClientTransport(
@@ -41,10 +39,10 @@ public class McpService(MaINSettings settings, IServiceProvider serviceProvider)
             BackendType.Gemini or BackendType.Vertex =>
                 await PromptWithSK(mcpClient, tools, config, messageHistory, backendType),
             BackendType.Anthropic =>
-                await PromptWithAnthropic(mcpClient, tools, config, messageHistory),
+                await PromptWithAnthropic(mcpClient, tools, config, messageHistory, maxIterations),
             BackendType.DeepSeek or BackendType.Ollama or BackendType.Self =>
                 throw new NotSupportedException($"{backendType} does not support MCP integration."),
-            _ => await PromptWithHttp(mcpClient, tools, config, messageHistory, backendType)
+            _ => await PromptWithHttp(mcpClient, tools, config, messageHistory, backendType, maxIterations)
         };
     }
 
@@ -55,7 +53,8 @@ public class McpService(MaINSettings settings, IServiceProvider serviceProvider)
         IList<McpClientTool> tools,
         Mcp config,
         List<Message> messageHistory,
-        BackendType backendType)
+        BackendType backendType,
+        int? maxIterations = null)
     {
         var (url, apiKey) = GetEndpointAndKey(backendType, config);
 
@@ -82,8 +81,8 @@ public class McpService(MaINSettings settings, IServiceProvider serviceProvider)
             })
             .ToList();
 
-        const int maxIterations = 10;
-        for (int i = 0; i < maxIterations; i++)
+        var effectiveMaxIterations = maxIterations ?? 10;
+        for (int i = 0; i < effectiveMaxIterations; i++)
         {
             var requestBody = new Dictionary<string, object>
             {
@@ -183,7 +182,8 @@ public class McpService(MaINSettings settings, IServiceProvider serviceProvider)
         IMcpClient mcpClient,
         IList<McpClientTool> tools,
         Mcp config,
-        List<Message> messageHistory)
+        List<Message> messageHistory,
+        int? maxIterations = null)
     {
         var apiKey = GetAnthropicKey() ?? throw new InvalidOperationException("Anthropic API key not configured.");
         var httpClientFactory = serviceProvider.GetRequiredService<IHttpClientFactory>();
@@ -211,8 +211,8 @@ public class McpService(MaINSettings settings, IServiceProvider serviceProvider)
             })
             .ToList();
 
-        const int maxIterations = 10;
-        for (int i = 0; i < maxIterations; i++)
+        var effectiveMaxIterations = maxIterations ?? 10;
+        for (int i = 0; i < effectiveMaxIterations; i++)
         {
             var requestBody = new Dictionary<string, object>
             {
@@ -262,6 +262,7 @@ public class McpService(MaINSettings settings, IServiceProvider serviceProvider)
                     });
                     continue;
                 }
+
                 return BuildResult(textContent, config.Model);
             }
 
@@ -317,6 +318,7 @@ public class McpService(MaINSettings settings, IServiceProvider serviceProvider)
                     ["content"] = resultText
                 });
             }
+
             messages.Add(new Dictionary<string, object> { ["role"] = "user", ["content"] = toolResults });
         }
 

--- a/src/MaIN.Services/Services/Steps/Commands/AnswerCommandHandler.cs
+++ b/src/MaIN.Services/Services/Steps/Commands/AnswerCommandHandler.cs
@@ -1,3 +1,4 @@
+using System.Text.Json;
 using MaIN.Domain.Configuration;
 using MaIN.Domain.Entities;
 using MaIN.Domain.Entities.Agents.Knowledge;
@@ -12,7 +13,6 @@ using MaIN.Services.Services.Models;
 using MaIN.Services.Services.Models.Commands;
 using MaIN.Services.Services.Steps.Commands.Abstract;
 using MaIN.Services.Utils;
-using System.Text.Json;
 
 namespace MaIN.Services.Services.Steps.Commands;
 
@@ -74,7 +74,9 @@ public class AnswerCommandHandler(
     private async Task<bool> ShouldUseKnowledge(Knowledge? knowledge, Chat chat, BackendType backend)
     {
         if (knowledge?.Index.Items is not { Count: > 0 })
+        {
             return false;
+        }
 
         var originalContent = chat.Messages.Last().Content;
 
@@ -156,7 +158,7 @@ public class AnswerCommandHandler(
 
         if (mcpConfig is not null)
         {
-            var result = await mcpService.Prompt(mcpConfig, chat.Messages);
+            var result = await mcpService.Prompt(mcpConfig, chat.Messages, chat.ToolsConfiguration?.MaxIterations);
             return result.Message;
         }
 

--- a/src/MaIN.Services/Services/Steps/Commands/AnswerCommandHandler.cs
+++ b/src/MaIN.Services/Services/Steps/Commands/AnswerCommandHandler.cs
@@ -158,7 +158,7 @@ public class AnswerCommandHandler(
 
         if (mcpConfig is not null)
         {
-            var result = await mcpService.Prompt(mcpConfig, chat.Messages, chat.ToolsConfiguration?.MaxIterations);
+            var result = await mcpService.Prompt(mcpConfig, chat.Messages);
             return result.Message;
         }
 

--- a/src/MaIN.Services/Services/Steps/Commands/McpCommandHandler.cs
+++ b/src/MaIN.Services/Services/Steps/Commands/McpCommandHandler.cs
@@ -11,7 +11,7 @@ public class McpCommandHandler(
 {
     public async Task<Message?> HandleAsync(McpCommand command)
     {
-        var result = await mcpService.Prompt(command.McpConfig, command.Chat.Messages);
+        var result = await mcpService.Prompt(command.McpConfig, command.Chat.Messages, command.Chat.ToolsConfiguration?.MaxIterations);
         return result.Message;
     }
 }


### PR DESCRIPTION
Allow user to set call LLM/MCP iteration limit to override the hardcoded value.

Example:
```c#
await AIHub.Chat()
      .WithModel(Models.OpenAi.Gpt4o)
      .WithMessage("Research the weather in Warsaw, then check forecast for next 3 days")
      .WithTools(new ToolsConfigurationBuilder()
          .AddTool("get_weather", "Get current weather",
              parameters: new { type = "object", properties = new { city = new { type = "string" } } },
              execute: (args) => $"Weather in {args}: sunny, 22°C")
          .WithMaxIterations(3)
          .Build())
      .CompleteAsync();
```

Do TODO: try to share logic of adding tool to the list across methods