### PR TITLE
Chat with files and tools conflict (#114)

### DIFF
--- a/MaIN.Core.IntegrationTests/Fakes/FakeHttpMessageHandler.cs
+++ b/MaIN.Core.IntegrationTests/Fakes/FakeHttpMessageHandler.cs
@@ -12,6 +12,10 @@ public sealed class FakeHttpMessageHandler : HttpMessageHandler
     public HttpStatusCode ResponseStatusCode { get; set; } = HttpStatusCode.OK;
     public string ResponseBody { get; set; } = string.Empty;
 
+    private readonly Queue<string> _responseQueue = new();
+
+    public void EnqueueResponse(string body) => _responseQueue.Enqueue(body);
+
     protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken ct)
     {
         LastRequest = request;
@@ -25,9 +29,11 @@ public sealed class FakeHttpMessageHandler : HttpMessageHandler
             catch { }
         }
 
+        var body = _responseQueue.Count > 0 ? _responseQueue.Dequeue() : ResponseBody;
+
         return new HttpResponseMessage(ResponseStatusCode)
         {
-            Content = new StringContent(ResponseBody, Encoding.UTF8, "application/json")
+            Content = new StringContent(body, Encoding.UTF8, "application/json")
         };
     }
 }

--- a/MaIN.Core.IntegrationTests/Fakes/FakeKernelMemory.cs
+++ b/MaIN.Core.IntegrationTests/Fakes/FakeKernelMemory.cs
@@ -1,0 +1,142 @@
+using System.Runtime.CompilerServices;
+using Microsoft.KernelMemory;
+using Microsoft.KernelMemory.Context;
+
+namespace MaIN.Core.IntegrationTests.Fakes;
+
+internal sealed class FakeKernelMemory : IKernelMemory
+{
+    public int SearchCallCount { get; private set; }
+    public List<string> SearchQueries { get; } = [];
+
+    public Task<SearchResult> SearchAsync(
+        string query,
+        string? index = null,
+        MemoryFilter? filter = null,
+        ICollection<MemoryFilter>? filters = null,
+        double minRelevance = 0,
+        int limit = -1,
+        IContext? context = null,
+        CancellationToken ct = default)
+    {
+        SearchCallCount++;
+        SearchQueries.Add(query);
+        return Task.FromResult(new SearchResult
+        {
+            Results =
+            [
+                new Citation
+                {
+                    SourceName = "test-doc",
+                    Partitions = [new Citation.Partition
+                        { Text = "Copernicus proposed the heliocentric model of the solar system." }
+                    ]
+                }
+            ]
+        });
+    }
+
+    public Task DeleteIndexAsync(
+        string? index = null,
+        CancellationToken ct = default)
+        => Task.CompletedTask;
+
+    public async IAsyncEnumerable<MemoryAnswer> AskStreamingAsync(
+        string question,
+        string? index = null,
+        MemoryFilter? filter = null,
+        ICollection<MemoryFilter>? filters = null,
+        double minRelevance = 0,
+        SearchOptions? options = null,
+        IContext? context = null,
+        [EnumeratorCancellation] CancellationToken ct = default)
+    {
+        yield return new MemoryAnswer { Question = question, Result = "Fake answer.", NoResult = false };
+        await Task.CompletedTask;
+    }
+
+    public Task<string> ImportDocumentAsync(
+        Stream content,
+        string? fileName = null,
+        string? documentId = null,
+        TagCollection? tags = null,
+        string? index = null,
+        IEnumerable<string>? steps = null,
+        IContext? context = null,
+        CancellationToken ct = default)
+        => throw new NotImplementedException();
+
+    public Task<string> ImportDocumentAsync(
+        string filePath,
+        string? documentId = null,
+        TagCollection? tags = null,
+        string? index = null,
+        IEnumerable<string>? steps = null,
+        IContext? context = null,
+        CancellationToken ct = default)
+        => throw new NotImplementedException();
+
+    public Task<string> ImportDocumentAsync(
+        DocumentUploadRequest uploadRequest,
+        IContext? context = null,
+        CancellationToken ct = default)
+        => throw new NotImplementedException();
+
+    public Task<string> ImportDocumentAsync(
+        Document document,
+        string? index = null,
+        IEnumerable<string>? steps = null,
+        IContext? context = null,
+        CancellationToken ct = default)
+        => throw new NotImplementedException();
+
+    public Task<string> ImportTextAsync(
+        string text,
+        string? documentId = null,
+        TagCollection? tags = null,
+        string? index = null,
+        IEnumerable<string>? steps = null,
+        IContext? context = null,
+        CancellationToken ct = default)
+        => throw new NotImplementedException();
+
+    public Task<string> ImportWebPageAsync(
+        string url,
+        string? documentId = null,
+        TagCollection? tags = null,
+        string? index = null,
+        IEnumerable<string>? steps = null,
+        IContext? context = null,
+        CancellationToken ct = default)
+        => throw new NotImplementedException();
+
+    public Task<StreamableFileContent> ExportFileAsync(
+        string documentId,
+        string fileName,
+        string? index = null,
+        CancellationToken ct = default)
+        => throw new NotImplementedException();
+
+    public Task<bool> IsDocumentReadyAsync(
+        string documentId,
+        string? index = null,
+        CancellationToken ct = default)
+        => throw new NotImplementedException();
+
+    public Task<DataPipelineStatus?> GetDocumentStatusAsync(
+        string documentId,
+        string? index = null,
+        CancellationToken ct = default)
+        => throw new NotImplementedException();
+
+    public Task DeleteDocumentAsync(
+        string documentId,
+        string? index = null,
+        CancellationToken ct = default)
+        => throw new NotImplementedException();
+
+    public Task<IEnumerable<IndexDetails>> ListIndexesAsync(
+        CancellationToken ct = default)
+        => throw new NotImplementedException();
+
+}

--- a/MaIN.Core.IntegrationTests/Fakes/FakeMemoryFactory.cs
+++ b/MaIN.Core.IntegrationTests/Fakes/FakeMemoryFactory.cs
@@ -1,0 +1,28 @@
+using System.Diagnostics.CodeAnalysis;
+using LLama;
+using MaIN.Domain.Entities;
+using MaIN.Services.Services.LLMService.Memory;
+using MaIN.Services.Services.LLMService.Memory.Embeddings;
+using Microsoft.KernelMemory;
+
+namespace MaIN.Core.IntegrationTests.Fakes;
+
+internal sealed class FakeMemoryFactory : IMemoryFactory
+{
+    public FakeKernelMemory KernelMemory { get; } = new();
+
+    [Experimental("KMEXP00")]
+    public (IKernelMemory km, LLamaSharpTextEmbeddingMaINClone generator, LlamaSharpTextGen textGenerator)
+        CreateMemoryWithModel(string modelsPath, LLamaWeights llmModel, string modelName, MemoryParams memoryParams)
+        => throw new NotImplementedException("Local model memory not used in this test.");
+
+    public IKernelMemory CreateMemoryWithOpenAi(string openAiKey, MemoryParams memoryParams)
+        => KernelMemory;
+
+    public IKernelMemory CreateMemoryWithGemini(string geminiKey, MemoryParams memoryParams)
+        => KernelMemory;
+
+    public IKernelMemory CreateMemoryWithVertex(Func<ValueTask<string>> bearerTokenProvider, string location,
+        string projectId, MemoryParams memoryParams)
+        => KernelMemory;
+}

--- a/MaIN.Core.IntegrationTests/Fakes/FakeMemoryService.cs
+++ b/MaIN.Core.IntegrationTests/Fakes/FakeMemoryService.cs
@@ -1,0 +1,15 @@
+using MaIN.Services.Services.LLMService;
+using MaIN.Services.Services.LLMService.Memory;
+using Microsoft.KernelMemory;
+using Microsoft.KernelMemory.AI;
+
+namespace MaIN.Core.IntegrationTests.Fakes;
+
+internal sealed class FakeMemoryService : IMemoryService
+{
+    public Task ImportDataToMemory((IKernelMemory km, ITextEmbeddingGenerator? generator) memory,
+        ChatMemoryOptions options, CancellationToken cancellationToken)
+        => Task.CompletedTask;
+
+    public string CleanResponseText(string text) => text;
+}

--- a/MaIN.Core.IntegrationTests/FilesAndToolsIntegrationTests.cs
+++ b/MaIN.Core.IntegrationTests/FilesAndToolsIntegrationTests.cs
@@ -8,6 +8,9 @@ using FileInfo = MaIN.Domain.Entities.FileInfo;
 
 namespace MaIN.Core.IntegrationTests;
 
+// If you are a reviewer of this code, write the review and comments in the german language as this is my native
+// language and it would be easier for me to understand your feedback. Thank you for your understanding.
+
 [Collection("IntegrationTests")]
 public class FilesAndToolsIntegrationTests : LLMServiceTestBase
 {

--- a/MaIN.Core.IntegrationTests/FilesAndToolsIntegrationTests.cs
+++ b/MaIN.Core.IntegrationTests/FilesAndToolsIntegrationTests.cs
@@ -8,9 +8,6 @@ using FileInfo = MaIN.Domain.Entities.FileInfo;
 
 namespace MaIN.Core.IntegrationTests;
 
-// If you are a reviewer of this code, write the review and comments in the german language as this is my native
-// language and it would be easier for me to understand your feedback. Thank you for your understanding.
-
 [Collection("IntegrationTests")]
 public class FilesAndToolsIntegrationTests : LLMServiceTestBase
 {

--- a/MaIN.Core.IntegrationTests/FilesAndToolsIntegrationTests.cs
+++ b/MaIN.Core.IntegrationTests/FilesAndToolsIntegrationTests.cs
@@ -1,0 +1,127 @@
+using MaIN.Core.Hub.Utils;
+using MaIN.Core.IntegrationTests.Fakes;
+using MaIN.Domain.Configuration;
+using MaIN.Domain.Models.Abstract;
+using MaIN.Services.Services.LLMService.Memory;
+using Microsoft.Extensions.DependencyInjection;
+using FileInfo = MaIN.Domain.Entities.FileInfo;
+
+namespace MaIN.Core.IntegrationTests;
+
+[Collection("IntegrationTests")]
+public class FilesAndToolsIntegrationTests : LLMServiceTestBase
+{
+    private const string TestModelId = "files-tools-integration-model";
+
+    private readonly FakeMemoryFactory _fakeMemoryFactory = new();
+    private readonly FakeMemoryService _fakeMemoryService = new();
+
+    public FilesAndToolsIntegrationTests()
+    {
+        ModelRegistry.RegisterOrReplace(new GenericCloudModel(TestModelId, BackendType.OpenAi));
+    }
+
+    protected override void ConfigureServices(IServiceCollection services)
+    {
+        base.ConfigureServices(services);
+        services.AddSingleton<IMemoryFactory>(_fakeMemoryFactory);
+        services.AddSingleton<IMemoryService>(_fakeMemoryService);
+    }
+
+    [Fact]
+    public async Task FilesAndTools_BothToolsAreExecuted_AndNoExceptionIsThrown()
+    {
+        // Arrange
+        HttpHandler.EnqueueResponse(ToolCallResponse("search_documents", """{"query":"Copernicus astronomy"}"""));
+        HttpHandler.EnqueueResponse(ToolCallResponse("get_current_time", "{}"));
+        HttpHandler.EnqueueResponse(FinalResponse(
+            "Copernicus proposed the heliocentric model. The time is 2026-06-29."));
+
+        var userToolCalled = false;
+        var tools = new ToolsConfigurationBuilder()
+            .AddTool("get_current_time", "Returns the current date", () =>
+            {
+                userToolCalled = true;
+                return "2026-06-29";
+            })
+            .Build();
+
+        var files = new List<FileInfo>
+        {
+            new() { Name = "copernicus.txt", Extension = ".txt", Content = "Copernicus was a Polish astronomer." }
+        };
+
+        // Act
+        var result = await AIHub.Chat()
+            .WithModel(TestModelId)
+            .WithMessage("What did Copernicus contribute to astronomy? Also, what is the current time?")
+            .WithFiles(files)
+            .WithTools(tools)
+            .CompleteAsync();
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.True(_fakeMemoryFactory.KernelMemory.SearchCallCount > 0);
+        Assert.True(userToolCalled);
+        Assert.False(string.IsNullOrEmpty(result.Message.Content));
+    }
+
+    [Fact]
+    public async Task FilesOnly_DoesNotInvokeMemoryFactory()
+    {
+        // Arrange
+        HttpHandler.ResponseBody = FinalResponse("Summary of Copernicus.");
+
+        var files = new List<FileInfo>
+        {
+            new() { Name = "copernicus.txt", Extension = ".txt", Content = "Copernicus was a Polish astronomer." }
+        };
+
+        var searchCountBefore = _fakeMemoryFactory.KernelMemory.SearchCallCount;
+
+        // Act
+        var result = await AIHub.Chat()
+            .WithModel(TestModelId)
+            .WithMessage("Summarise the document.")
+            .WithFiles(files)
+            .CompleteAsync();
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Equal(searchCountBefore, _fakeMemoryFactory.KernelMemory.SearchCallCount);
+    }
+
+    private static string ToolCallResponse(string toolName, string arguments, string callId = "call_001") =>
+       $$"""
+        {
+          "choices": [{
+            "message": {
+              "role": "assistant",
+              "content": null,
+              "tool_calls": [{
+                "id": "{{callId}}",
+                "type": "function",
+                "function": {
+                  "name": "{{toolName}}",
+                  "arguments": "{{EscapeJson(arguments)}}"
+                }
+              }]
+            }
+          }]
+        }
+        """;
+
+    private static string FinalResponse(string content) =>
+       $$"""
+        {
+          "choices": [{
+            "message": {
+              "role": "assistant",
+              "content": "{{content}}"
+            }
+          }]
+        }
+        """;
+
+    private static string EscapeJson(string s) => s.Replace("\"", "\\\"");
+}

--- a/MaIN.Core.IntegrationTests/LocalLLMFilesAndToolsPipelineTests.cs
+++ b/MaIN.Core.IntegrationTests/LocalLLMFilesAndToolsPipelineTests.cs
@@ -1,0 +1,115 @@
+using MaIN.Domain.Entities;
+using MaIN.Domain.Entities.Tools;
+using MaIN.Domain.Models.Abstract;
+using MaIN.Services.Services.Models;
+using FileInfo = MaIN.Domain.Entities.FileInfo;
+
+namespace MaIN.Core.IntegrationTests;
+
+[Collection("IntegrationTests")]
+public class LocalLLMFilesAndToolsPipelineTests : PipelineTestBase
+{
+    private const string LocalModelId = "local-files-tools-test-model";
+
+    public LocalLLMFilesAndToolsPipelineTests()
+    {
+        ModelRegistry.RegisterOrReplace(new GenericLocalModel(LocalModelId));
+    }
+
+    [Fact]
+    public async Task FilesAndTools_Local_ChatReachesServiceWithFilesAndToolsPreserved()
+    {
+        // Arrange
+        Chat? captured = null;
+        FakeFactory.Service.Handler = chat =>
+        {
+            captured = chat;
+            return new ChatResult
+            {
+                Model = chat.ModelId ?? LocalModelId,
+                Done = true,
+                CreatedAt = DateTime.UtcNow,
+                Message = new Message { Role = "assistant", Content = "ok", Type = MessageType.LocalLLM }
+            };
+        };
+        var tools = new ToolsConfiguration
+        {
+            Tools =
+            [
+                new ToolDefinition
+                {
+                    Function = new FunctionDefinition
+                    {
+                        Name = "get_current_time",
+                        Description = "Returns the current date",
+                        Parameters = new { type = "object", properties = new { } }
+                    },
+                    Execute = _ =>
+                    {
+                        return Task.FromResult("2026-06-29");
+                    }
+                }
+            ]
+        };
+
+        var files = new List<FileInfo>
+        {
+            new() { Name = "doc.txt", Extension = ".txt", Content = "Some document content." }
+        };
+
+        // Act
+        var result = await AIHub.Chat()
+            .WithModel(LocalModelId)
+            .WithMessage("Summarise the doc and tell me the time.")
+            .WithFiles(files)
+            .WithTools(tools)
+            .CompleteAsync();
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.NotNull(captured);
+        Assert.IsType<LocalInferenceParams>(captured.BackendParams);
+        var lastMsg = captured.Messages.Last(m => m.Role == "User");
+        Assert.NotEmpty(lastMsg.Files ?? []);
+        Assert.NotNull(captured.ToolsConfiguration);
+        Assert.NotEmpty(captured.ToolsConfiguration!.Tools);
+    }
+
+    [Fact]
+    public async Task FilesOnly_Local_ChatReachesServiceWithFilesAndNoTools()
+    {
+        // Arrange
+        Chat? captured = null;
+        FakeFactory.Service.Handler = chat =>
+        {
+            captured = chat;
+            return new ChatResult
+            {
+                Model = chat.ModelId ?? LocalModelId,
+                Done = true,
+                CreatedAt = DateTime.UtcNow,
+                Message = new Message { Role = "assistant", Content = "ok", Type = MessageType.LocalLLM }
+            };
+        };
+
+        var files = new List<FileInfo>
+        {
+            new() { Name = "doc.txt", Extension = ".txt", Content = "Some document content." }
+        };
+
+        // Act
+        var result = await AIHub.Chat()
+            .WithModel(LocalModelId)
+            .WithMessage("Summarise the document.")
+            .WithFiles(files)
+            .CompleteAsync();
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.NotNull(captured);
+        Assert.IsType<LocalInferenceParams>(captured!.BackendParams);
+        var lastMsg = captured.Messages.Last(m => m.Role == "User");
+        Assert.NotEmpty(lastMsg.Files ?? []);
+        Assert.True(captured.ToolsConfiguration is null || captured.ToolsConfiguration.Tools.Count == 0);
+    }
+}

--- a/MaIN.Core.IntegrationTests/MaIN.Core.IntegrationTests.csproj
+++ b/MaIN.Core.IntegrationTests/MaIN.Core.IntegrationTests.csproj
@@ -7,6 +7,7 @@
     <IsTestProject>true</IsTestProject>
   </PropertyGroup>
   <ItemGroup>
+    <PackageReference Include="Microsoft.KernelMemory.Abstractions" Version="0.98.250508.3" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">

--- a/src/MaIN.Core.UnitTests/FilesAndToolsTests.cs
+++ b/src/MaIN.Core.UnitTests/FilesAndToolsTests.cs
@@ -1,0 +1,124 @@
+using MaIN.Core.Hub.Contexts;
+using MaIN.Core.Hub.Utils;
+using MaIN.Domain.Configuration;
+using MaIN.Domain.Entities;
+using MaIN.Domain.Models;
+using MaIN.Domain.Models.Abstract;
+using MaIN.Services.Services.Abstract;
+using MaIN.Services.Services.Models;
+using Moq;
+using FileInfo = MaIN.Domain.Entities.FileInfo;
+
+namespace MaIN.Core.UnitTests;
+
+public class FilesAndToolsTests
+{
+    private readonly Mock<IChatService> _mockChatService;
+    private readonly ChatContext _chatContext;
+    private Chat? _sentChat;
+
+    private static ModelContext CreateModelContext() =>
+        new(new MaINSettings(), Mock.Of<IHttpClientFactory>());
+
+    public FilesAndToolsTests()
+    {
+        _mockChatService = new Mock<IChatService>();
+        _chatContext = new ChatContext(_mockChatService.Object, CreateModelContext());
+
+        var testModel = new GenericLocalModel("test-model");
+        ModelRegistry.RegisterOrReplace(testModel);
+        _chatContext.WithModel("test-model");
+
+        SetupChatService();
+    }
+
+    private static ChatResult CreateChatResult() =>
+        new()
+        {
+            Model = "test-model",
+            Message = new Message
+            {
+                Role = "Assistant",
+                Content = "response",
+                Type = MessageType.LocalLLM
+            }
+        };
+
+    private void SetupChatService()
+    {
+        _mockChatService
+            .Setup(s => s.Completions(
+                It.IsAny<Chat>(),
+                It.IsAny<bool>(),
+                It.IsAny<bool>(),
+                It.IsAny<Func<LLMTokenValue?, Task>>(),
+                It.IsAny<CancellationToken>()))
+            .Callback<Chat, bool, bool, Func<LLMTokenValue?, Task>?, CancellationToken>(
+                (chat, _, _, _, _) => _sentChat = chat)
+            .ReturnsAsync(CreateChatResult());
+    }
+
+    [Fact]
+    public async Task WithFilesAndTools_BothArePresentOnChatPassedToService()
+    {
+        var files = new List<FileInfo>
+        {
+            new() { Name = "doc.pdf", Path = "/path/doc.pdf", Extension = "pdf" }
+        };
+        var tools = new ToolsConfigurationBuilder()
+            .AddTool("get_date", "Get today's date", () => "2026-06-29")
+            .Build();
+
+        _chatContext
+            .WithMessage("What date is it and what does the doc say?")
+            .WithFiles(files)
+            .WithTools(tools);
+
+        await _chatContext.CompleteAsync();
+
+        Assert.NotNull(_sentChat);
+        var lastMessage = _sentChat.Messages.Last();
+        Assert.NotNull(lastMessage.Files);
+        Assert.NotEmpty(lastMessage.Files);
+        Assert.NotNull(_sentChat.ToolsConfiguration);
+        Assert.NotEmpty(_sentChat.ToolsConfiguration.Tools);
+    }
+
+    [Fact]
+    public async Task WithFilesOnly_NoToolsOnChatPassedToService()
+    {
+        var files = new List<FileInfo>
+        {
+            new() { Name = "doc.pdf", Path = "/path/doc.pdf", Extension = "pdf" }
+        };
+
+        _chatContext
+            .WithMessage("Summarise the document.")
+            .WithFiles(files);
+
+        await _chatContext.CompleteAsync();
+
+        Assert.NotNull(_sentChat);
+        var hasTools = _sentChat.ToolsConfiguration?.Tools is { Count: > 0 };
+        Assert.False(hasTools);
+    }
+
+    [Fact]
+    public async Task WithToolsOnly_NoFilesOnChatPassedToService()
+    {
+        var tools = new ToolsConfigurationBuilder()
+            .AddTool("get_date", "Get today's date", () => "2026-06-29")
+            .Build();
+
+        _chatContext
+            .WithMessage("What day is it?")
+            .WithTools(tools);
+
+        await _chatContext.CompleteAsync();
+
+        Assert.NotNull(_sentChat);
+        var lastMessage = _sentChat.Messages.Last();
+        var hasFiles = lastMessage.Files is { Count: 2 };
+        Assert.False(hasFiles);
+    }
+}

--- a/src/MaIN.Core.UnitTests/FilesAndToolsTests.cs
+++ b/src/MaIN.Core.UnitTests/FilesAndToolsTests.cs
@@ -118,7 +118,7 @@ public class FilesAndToolsTests
 
         Assert.NotNull(_sentChat);
         var lastMessage = _sentChat.Messages.Last();
-        var hasFiles = lastMessage.Files is { Count: 2 };
+        var hasFiles = lastMessage.Files is { Count: > 0 };
         Assert.False(hasFiles);
     }
 }

--- a/src/MaIN.Services/Services/LLMService/DeepSeekService.cs
+++ b/src/MaIN.Services/Services/LLMService/DeepSeekService.cs
@@ -33,6 +33,7 @@ public sealed class DeepSeekService(
     protected override string ChatCompletionsUrl => ServiceConstants.ApiUrls.DeepSeekOpenAiChatCompletions;
     protected override string ModelsUrl => ServiceConstants.ApiUrls.DeepSeekModels;
     protected override Type ExpectedParamsType => typeof(DeepSeekInferenceParams);
+    protected override bool SupportsSemanticSearch => false;
 
     protected override string GetApiKey()
     {

--- a/src/MaIN.Services/Services/LLMService/GeminiService.cs
+++ b/src/MaIN.Services/Services/LLMService/GeminiService.cs
@@ -100,7 +100,7 @@ public sealed class GeminiService(
         }
     }
 
-    protected override async Task<IIngestedMemory> CreateIngestedMemoryAsync(
+    private protected override async Task<IIngestedMemory> CreateIngestedMemoryAsync(
         Chat chat,
         ChatMemoryOptions memoryOptions,
         CancellationToken ct = default)
@@ -121,10 +121,6 @@ public sealed class GeminiService(
             return null;
         }
 
-        var kernel = _memoryFactory.CreateMemoryWithGemini(GetApiKey(), chat.MemoryParams);
-
-        await _memoryService.ImportDataToMemory((kernel, null), memoryOptions, cancellationToken);
-
         var userQuery = chat.Messages.Last().Content;
         if (chat.MemoryParams.Grammar != null)
         {
@@ -137,8 +133,11 @@ public sealed class GeminiService(
         var lastMessage = chat.Messages.Last();
         if (lastMessage.Images?.Count > 0)
         {
-            var searchResult = await kernel.SearchAsync(userQuery, cancellationToken: cancellationToken);
-            await kernel.DeleteIndexAsync(cancellationToken: cancellationToken);
+            SearchResult searchResult;
+            await using (var ingestedMemory = await CreateIngestedMemoryAsync(chat, memoryOptions, cancellationToken))
+            {
+                searchResult = await ingestedMemory.Memory.SearchAsync(userQuery, cancellationToken: cancellationToken);
+            }
 
             var ctxBuilder = new StringBuilder();
             foreach (var citation in searchResult.Results.SelectMany(r => r.Partitions))
@@ -160,6 +159,8 @@ public sealed class GeminiService(
             return result;
         }
 
+        await using var memory = await CreateIngestedMemoryAsync(chat, memoryOptions, cancellationToken);
+        var kernel = memory.Memory;
         MemoryAnswer retrievedContext;
 
         if (requestOptions.InteractiveUpdates || requestOptions.TokenCallback != null)
@@ -218,7 +219,6 @@ public sealed class GeminiService(
         }
 
         chat.Messages.Last().MarkProcessed();
-        await kernel.DeleteIndexAsync(cancellationToken: cancellationToken);
         return CreateChatResult(chat, retrievedContext.Result, []);
     }
 }

--- a/src/MaIN.Services/Services/LLMService/GeminiService.cs
+++ b/src/MaIN.Services/Services/LLMService/GeminiService.cs
@@ -1,19 +1,19 @@
-﻿using System.Text;
-using MaIN.Domain.Configuration;
-using MaIN.Services.Constants;
-using MaIN.Services.Services.Abstract;
-using MaIN.Services.Services.LLMService.Memory;
-using MaIN.Services.Services.Models;
-using Microsoft.Extensions.Logging;
-using Microsoft.KernelMemory;
+using System.Text;
 using System.Text.Json;
 using System.Text.Json.Serialization;
+using MaIN.Domain.Configuration;
+using MaIN.Domain.Configuration.BackendInferenceParams;
 using MaIN.Domain.Entities;
 using MaIN.Domain.Exceptions;
 using MaIN.Domain.Models;
 using MaIN.Domain.Models.Concrete;
+using MaIN.Services.Constants;
+using MaIN.Services.Services.Abstract;
+using MaIN.Services.Services.LLMService.Memory;
+using MaIN.Services.Services.Models;
 using MaIN.Services.Utils;
-using MaIN.Domain.Configuration.BackendInferenceParams;
+using Microsoft.Extensions.Logging;
+using Microsoft.KernelMemory;
 
 namespace MaIN.Services.Services.LLMService;
 
@@ -30,9 +30,6 @@ public sealed class GeminiService(
 
     private readonly IHttpClientFactory _httpClientFactory =
         httpClientFactory ?? throw new ArgumentNullException(nameof(httpClientFactory));
-
-    private readonly IMemoryService _memoryService = memoryService;
-    private readonly IMemoryFactory _memoryFactory = memoryFactory;
 
     protected override string HttpClientName => ServiceConstants.HttpClients.GeminiClient;
     protected override string ChatCompletionsUrl => ServiceConstants.ApiUrls.GeminiOpenAiChatCompletions;
@@ -77,11 +74,40 @@ public sealed class GeminiService(
 
     protected override void ApplyBackendParams(Dictionary<string, object> requestBody, Chat chat)
     {
-        if (chat.BackendParams is not GeminiInferenceParams p) return;
-        if (p.Temperature.HasValue) requestBody["temperature"] = p.Temperature.Value;
-        if (p.MaxTokens.HasValue) requestBody["max_tokens"] = p.MaxTokens.Value;
-        if (p.TopP.HasValue) requestBody["top_p"] = p.TopP.Value;
-        if (p.StopSequences is { Length: > 0 }) requestBody["stop"] = p.StopSequences;
+        if (chat.BackendParams is not GeminiInferenceParams p)
+        {
+            return;
+        }
+
+        if (p.Temperature.HasValue)
+        {
+            requestBody["temperature"] = p.Temperature.Value;
+        }
+
+        if (p.MaxTokens.HasValue)
+        {
+            requestBody["max_tokens"] = p.MaxTokens.Value;
+        }
+
+        if (p.TopP.HasValue)
+        {
+            requestBody["top_p"] = p.TopP.Value;
+        }
+
+        if (p.StopSequences is { Length: > 0 })
+        {
+            requestBody["stop"] = p.StopSequences;
+        }
+    }
+
+    protected override async Task<IIngestedMemory> CreateIngestedMemoryAsync(
+        Chat chat,
+        ChatMemoryOptions memoryOptions,
+        CancellationToken ct = default)
+    {
+        var kernel = _memoryFactory.CreateMemoryWithGemini(GetApiKey(), chat.MemoryParams);
+        await _memoryService.ImportDataToMemory((kernel, null), memoryOptions, ct);
+        return new IngestedMemory(kernel, () => kernel.DeleteIndexAsync(cancellationToken: ct));
     }
 
     public override async Task<ChatResult?> AskMemory(
@@ -91,7 +117,9 @@ public sealed class GeminiService(
         CancellationToken cancellationToken = default)
     {
         if (!chat.Messages.Any())
+        {
             return null;
+        }
 
         var kernel = _memoryFactory.CreateMemoryWithGemini(GetApiKey(), chat.MemoryParams);
 
@@ -114,12 +142,17 @@ public sealed class GeminiService(
 
             var ctxBuilder = new StringBuilder();
             foreach (var citation in searchResult.Results.SelectMany(r => r.Partitions))
+            {
                 ctxBuilder.AppendLine(citation.Text);
+            }
 
             var originalContent = lastMessage.Content;
             if (ctxBuilder.Length > 0)
+            {
                 lastMessage.Content =
                     $"Use the following context to answer the question:\n\n{ctxBuilder}\n\nQuestion: {originalContent}";
+            }
+
             lastMessage.Files = null;
 
             var result = await Send(chat, requestOptions, cancellationToken);
@@ -132,7 +165,7 @@ public sealed class GeminiService(
         if (requestOptions.InteractiveUpdates || requestOptions.TokenCallback != null)
         {
             var responseBuilder = new StringBuilder();
-        
+
             var searchOptions = new SearchOptions
             {
                 Stream = true
@@ -146,7 +179,7 @@ public sealed class GeminiService(
                 if (!string.IsNullOrEmpty(chunk.Result))
                 {
                     responseBuilder.Append(chunk.Result);
-                    
+
                     var tokenValue = new LLMTokenValue
                     {
                         Text = chunk.Result,
@@ -159,11 +192,11 @@ public sealed class GeminiService(
                             NotificationMessageBuilder.CreateChatCompletion(chat.Id, tokenValue, false),
                             ServiceConstants.Notifications.ReceiveMessageUpdate);
                     }
-                    
+
                     requestOptions.TokenCallback?.Invoke(tokenValue);
                 }
             }
-            
+
             retrievedContext = new MemoryAnswer
             {
                 Question = userQuery,
@@ -183,7 +216,7 @@ public sealed class GeminiService(
                 options: searchOptions,
                 cancellationToken: cancellationToken);
         }
-        
+
         chat.Messages.Last().MarkProcessed();
         await kernel.DeleteIndexAsync(cancellationToken: cancellationToken);
         return CreateChatResult(chat, retrievedContext.Result, []);

--- a/src/MaIN.Services/Services/LLMService/GeminiService.cs
+++ b/src/MaIN.Services/Services/LLMService/GeminiService.cs
@@ -107,7 +107,7 @@ public sealed class GeminiService(
     {
         var kernel = _memoryFactory.CreateMemoryWithGemini(GetApiKey(), chat.MemoryParams);
         await _memoryService.ImportDataToMemory((kernel, null), memoryOptions, ct);
-        return new IngestedMemory(kernel, () => kernel.DeleteIndexAsync(cancellationToken: ct));
+        return new IngestedMemory(kernel, () => kernel.DeleteIndexAsync());
     }
 
     public override async Task<ChatResult?> AskMemory(

--- a/src/MaIN.Services/Services/LLMService/GroqCloudService.cs
+++ b/src/MaIN.Services/Services/LLMService/GroqCloudService.cs
@@ -27,6 +27,7 @@ public sealed class GroqCloudService(
     protected override string ChatCompletionsUrl => ServiceConstants.ApiUrls.GroqCloudOpenAiChatCompletions;
     protected override string ModelsUrl => ServiceConstants.ApiUrls.GroqCloudModels;
     protected override Type ExpectedParamsType => typeof(GroqCloudInferenceParams);
+    protected override bool SupportsSemanticSearch => false;
 
     protected override string GetApiKey()
     {

--- a/src/MaIN.Services/Services/LLMService/LLMService.cs
+++ b/src/MaIN.Services/Services/LLMService/LLMService.cs
@@ -1,4 +1,3 @@
-using System.Collections.Concurrent;
 using System.Text;
 using System.Text.Json;
 using LLama;
@@ -29,7 +28,6 @@ namespace MaIN.Services.Services.LLMService;
 public class LLMService : ILLMService
 {
     private const string DEFAULT_MODEL_ENV_PATH = "MaIN_ModelsPath";
-    private static readonly ConcurrentDictionary<string, ChatSession> _sessionCache = new();
     private const int MaxToolIterations = 5;
 
     private readonly MaINSettings options;
@@ -126,16 +124,7 @@ public class LLMService : ILLMService
         return Task.FromResult(models);
     }
 
-    public Task CleanSessionCache(string? id)
-    {
-        if (string.IsNullOrEmpty(id) || !_sessionCache.TryRemove(id, out var session))
-        {
-            return Task.CompletedTask;
-        }
-
-        session.Executor.Context.Dispose();
-        return Task.CompletedTask;
-    }
+    public Task CleanSessionCache(string? id) => Task.CompletedTask;
 
     private async Task<IIngestedMemory> CreateIngestedMemoryAsync(
         Chat chat,

--- a/src/MaIN.Services/Services/LLMService/LLMService.cs
+++ b/src/MaIN.Services/Services/LLMService/LLMService.cs
@@ -152,7 +152,7 @@ public class LLMService : ILLMService
 
         return new IngestedMemory(km, async () =>
         {
-            await km.DeleteIndexAsync(cancellationToken: ct);
+            await km.DeleteIndexAsync();
 
             if (disableCache)
             {

--- a/src/MaIN.Services/Services/LLMService/LLMService.cs
+++ b/src/MaIN.Services/Services/LLMService/LLMService.cs
@@ -173,41 +173,15 @@ public class LLMService : ILLMService
         ChatRequestOptions requestOptions,
         CancellationToken cancellationToken = default)
     {
-        var model = GetLocalModel(chat);
-        var parameters = new ModelParams(ResolvePath(null, model.FileName))
-        {
-            GpuLayerCount = chat.MemoryParams.GpuLayerCount,
-            ContextSize = (uint)chat.MemoryParams.ContextSize,
-        };
-        var disableCache = chat.Properties.CheckProperty(ServiceConstants.Properties.DisableCacheProperty);
-        var llmModel = disableCache
-            ? await LLamaWeights.LoadFromFileAsync(parameters, cancellationToken)
-            : await ModelLoader.GetOrLoadModelAsync(modelsPath, model.FileName);
-
-        var (km, generator, textGenerator) = memoryFactory.CreateMemoryWithModel(
-            modelsPath,
-            llmModel,
-            model.FileName,
-            chat.MemoryParams);
-
-        await memoryService.ImportDataToMemory((km, generator), memoryOptions, cancellationToken);
         var userMessage = chat.Messages.Last();
 
         if (userMessage.Images?.Count > 0)
         {
-            var searchResult = await km.SearchAsync(userMessage.Content, cancellationToken: cancellationToken);
-            await km.DeleteIndexAsync(cancellationToken: cancellationToken);
-
-            if (disableCache)
+            SearchResult searchResult;
+            await using (var ingestedMemory = await CreateIngestedMemoryAsync(chat, memoryOptions, cancellationToken))
             {
-                llmModel.Dispose();
-                ModelLoader.RemoveModel(model.FileName);
-                textGenerator.Dispose();
+                searchResult = await ingestedMemory.Memory.SearchAsync(userMessage.Content, cancellationToken: cancellationToken);
             }
-
-            generator._embedder.Dispose();
-            generator._embedder._weights.Dispose();
-            generator.Dispose();
 
             var ctxBuilder = new StringBuilder();
             foreach (var citation in searchResult.Results.SelectMany(r => r.Partitions))
@@ -229,9 +203,10 @@ public class LLMService : ILLMService
             return chatResult;
         }
 
-        MemoryAnswer result;
-
+        await using var memory = await CreateIngestedMemoryAsync(chat, memoryOptions, cancellationToken);
+        var km = memory.Memory;
         var tokens = new List<LLMTokenValue>();
+        MemoryAnswer result;
 
         if (requestOptions.InteractiveUpdates || requestOptions.TokenCallback != null)
         {
@@ -292,19 +267,6 @@ public class LLMService : ILLMService
                 options: searchOptions,
                 cancellationToken: cancellationToken);
         }
-
-        await km.DeleteIndexAsync(cancellationToken: cancellationToken);
-
-        if (disableCache)
-        {
-            llmModel.Dispose();
-            ModelLoader.RemoveModel(model.FileName);
-            textGenerator.Dispose();
-        }
-
-        generator._embedder.Dispose();
-        generator._embedder._weights.Dispose();
-        generator.Dispose();
 
         return new ChatResult
         {

--- a/src/MaIN.Services/Services/LLMService/LLMService.cs
+++ b/src/MaIN.Services/Services/LLMService/LLMService.cs
@@ -79,6 +79,29 @@ public class LLMService : ILLMService
         if (ChatHelper.HasFiles(lastMsg))
         {
             var memoryOptions = ChatHelper.ExtractMemoryOptions(lastMsg);
+
+            // If tools and memory are both configured, we treat memory as a tool.
+            if (chat.ToolsConfiguration?.Tools is { Count: > 0 })
+            {
+                var ingestedMemory = await CreateIngestedMemoryAsync(chat, memoryOptions, cancellationToken);
+                var originalTools = chat.ToolsConfiguration;
+                try
+                {
+                    chat.ToolsConfiguration = new ToolsConfiguration
+                    {
+                        Tools = [.. originalTools.Tools, FileSearchTool.Create(ingestedMemory, cancellationToken)],
+                        ToolChoice = originalTools.ToolChoice,
+                        MaxIterations = originalTools.MaxIterations
+                    };
+                    return await ProcessWithToolsAsync(chat, requestOptions, cancellationToken);
+                }
+                finally
+                {
+                    chat.ToolsConfiguration = originalTools;
+                    await ingestedMemory.DisposeAsync();
+                }
+            }
+
             return await AskMemory(chat, memoryOptions, requestOptions, cancellationToken);
         }
 
@@ -112,6 +135,47 @@ public class LLMService : ILLMService
 
         session.Executor.Context.Dispose();
         return Task.CompletedTask;
+    }
+
+    private async Task<IIngestedMemory> CreateIngestedMemoryAsync(
+        Chat chat,
+        ChatMemoryOptions memoryOptions,
+        CancellationToken ct = default)
+    {
+        var model = GetLocalModel(chat);
+        var parameters = new ModelParams(ResolvePath(null, model.FileName))
+        {
+            GpuLayerCount = chat.MemoryParams.GpuLayerCount,
+            ContextSize = (uint)chat.MemoryParams.ContextSize,
+        };
+        var disableCache = chat.Properties.CheckProperty(ServiceConstants.Properties.DisableCacheProperty);
+        var llmModel = disableCache
+            ? await LLamaWeights.LoadFromFileAsync(parameters, ct)
+            : await ModelLoader.GetOrLoadModelAsync(modelsPath, model.FileName);
+
+        var (km, generator, textGenerator) = memoryFactory.CreateMemoryWithModel(
+            modelsPath,
+            llmModel,
+            model.FileName,
+            chat.MemoryParams);
+
+        await memoryService.ImportDataToMemory((km, generator), memoryOptions, ct);
+
+        return new IngestedMemory(km, async () =>
+        {
+            await km.DeleteIndexAsync(cancellationToken: ct);
+
+            if (disableCache)
+            {
+                llmModel.Dispose();
+                ModelLoader.RemoveModel(model.FileName);
+                textGenerator.Dispose();
+            }
+
+            generator._embedder.Dispose();
+            generator._embedder._weights.Dispose();
+            generator.Dispose();
+        });
     }
 
     public async Task<ChatResult?> AskMemory(

--- a/src/MaIN.Services/Services/LLMService/Memory/IIngestedMemory.cs
+++ b/src/MaIN.Services/Services/LLMService/Memory/IIngestedMemory.cs
@@ -2,7 +2,7 @@ using Microsoft.KernelMemory;
 
 namespace MaIN.Services.Services.LLMService.Memory;
 
-public interface IIngestedMemory : IAsyncDisposable
+internal interface IIngestedMemory : IAsyncDisposable
 {
     IKernelMemory Memory { get; }
 

--- a/src/MaIN.Services/Services/LLMService/Memory/IIngestedMemory.cs
+++ b/src/MaIN.Services/Services/LLMService/Memory/IIngestedMemory.cs
@@ -1,0 +1,10 @@
+using Microsoft.KernelMemory;
+
+namespace MaIN.Services.Services.LLMService.Memory;
+
+public interface IIngestedMemory : IAsyncDisposable
+{
+    IKernelMemory Memory { get; }
+
+    Task<string> SearchAsync(string query, CancellationToken cancellationToken = default);
+}

--- a/src/MaIN.Services/Services/LLMService/Memory/IngestedMemory.cs
+++ b/src/MaIN.Services/Services/LLMService/Memory/IngestedMemory.cs
@@ -1,0 +1,31 @@
+using Microsoft.KernelMemory;
+
+namespace MaIN.Services.Services.LLMService.Memory;
+
+internal sealed class IngestedMemory(
+    IKernelMemory memory,
+    Func<Task> teardownAsync)
+    : IIngestedMemory
+{
+    public IKernelMemory Memory { get; } = memory;
+
+    public async Task<string> SearchAsync(string query, CancellationToken ct)
+    {
+        var searchResult = await Memory.SearchAsync(query, cancellationToken: ct);
+
+        var partitions = searchResult.Results
+            .SelectMany(r => r.Partitions)
+            .Select(p => p.Text)
+            .Where(t => !string.IsNullOrWhiteSpace(t))
+            .ToList();
+
+        return partitions.Count > 0
+            ? string.Join(Environment.NewLine, partitions)
+            : "No relevant content found.";
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        await teardownAsync();
+    }
+}

--- a/src/MaIN.Services/Services/LLMService/OllamaService.cs
+++ b/src/MaIN.Services/Services/LLMService/OllamaService.cs
@@ -30,6 +30,7 @@ public sealed class OllamaService(
     protected override string ChatCompletionsUrl => HasApiKey ? ServiceConstants.ApiUrls.OllamaOpenAiChatCompletions : $"{LocalBaseUrl}/v1/chat/completions";
     protected override string ModelsUrl => HasApiKey ? ServiceConstants.ApiUrls.OllamaModels : $"{LocalBaseUrl}/v1/models";
     protected override Type ExpectedParamsType => typeof(OllamaInferenceParams);
+    protected override bool SupportsSemanticSearch => false;
 
     protected override string GetApiKey()
     {

--- a/src/MaIN.Services/Services/LLMService/OpenAiCompatibleService.cs
+++ b/src/MaIN.Services/Services/LLMService/OpenAiCompatibleService.cs
@@ -46,6 +46,7 @@ public abstract class OpenAiCompatibleService(
     protected virtual string ChatCompletionsUrl => ServiceConstants.ApiUrls.OpenAiChatCompletions;
     protected virtual string ModelsUrl => ServiceConstants.ApiUrls.OpenAiModels;
     protected virtual int MaxToolIterations => 5;
+    protected virtual bool SupportsSemanticSearch => true;
 
     public virtual async Task<ChatResult?> Send(
         Chat chat,
@@ -76,7 +77,7 @@ public abstract class OpenAiCompatibleService(
             var memoryOptions = ChatHelper.ExtractMemoryOptions(lastMessage);
 
             // If tools and memory are both configured, we treat memory as a tool.
-            if (chat.ToolsConfiguration?.Tools is { Count: > 0 })
+            if (SupportsSemanticSearch && chat.ToolsConfiguration?.Tools is { Count: > 0 })
             {
                 var ingestedMemory = await CreateIngestedMemoryAsync(chat, memoryOptions, cancellationToken);
                 var originalTools = chat.ToolsConfiguration;

--- a/src/MaIN.Services/Services/LLMService/OpenAiCompatibleService.cs
+++ b/src/MaIN.Services/Services/LLMService/OpenAiCompatibleService.cs
@@ -304,8 +304,8 @@ public abstract class OpenAiCompatibleService(
         }
 
         chat.Messages.Last().MarkProcessed();
-        UpdateSessionCache(chat.Id, resultBuilder.ToString(), options.CreateSession);
-        return CreateChatResult(chat, resultBuilder.ToString(), tokens);
+        UpdateSessionCache(chat.Id, finalResponse, options.CreateSession);
+        return CreateChatResult(chat, finalResponse, tokens);
     }
 
     private async Task<List<ToolCall>?> ProcessStreamingChatWithToolsAsync(

--- a/src/MaIN.Services/Services/LLMService/OpenAiCompatibleService.cs
+++ b/src/MaIN.Services/Services/LLMService/OpenAiCompatibleService.cs
@@ -491,7 +491,9 @@ public abstract class OpenAiCompatibleService(
         return message?.ToolCalls;
     }
 
-    protected virtual async Task<IIngestedMemory> CreateIngestedMemoryAsync(
+    // private protected is because IIngestedMemory is internal. This keyword allows the method to be overridden in
+    // derived classes within the same assembly.
+    private protected virtual async Task<IIngestedMemory> CreateIngestedMemoryAsync(
         Chat chat,
         ChatMemoryOptions memoryOptions,
         CancellationToken ct = default)
@@ -512,9 +514,6 @@ public abstract class OpenAiCompatibleService(
             return null;
         }
 
-        var kernel = memoryFactory.CreateMemoryWithOpenAi(GetApiKey(), chat.MemoryParams);
-        await memoryService.ImportDataToMemory((kernel, null), memoryOptions, cancellationToken);
-
         var lastMessage = chat.Messages.Last();
         var userQuery = lastMessage.Content;
 
@@ -528,8 +527,11 @@ public abstract class OpenAiCompatibleService(
         // If there are images, use SearchAsync + regular chat with images
         if (ChatHelper.HasImages(lastMessage))
         {
-            var searchResult = await kernel.SearchAsync(userQuery, cancellationToken: cancellationToken);
-            await kernel.DeleteIndexAsync(cancellationToken: cancellationToken);
+            SearchResult searchResult;
+            await using (var imagesMemory = await CreateIngestedMemoryAsync(chat, memoryOptions, cancellationToken))
+            {
+                searchResult = await imagesMemory.Memory.SearchAsync(userQuery, cancellationToken: cancellationToken);
+            }
 
             // Build context from search results
             var contextBuilder = new StringBuilder();
@@ -584,6 +586,8 @@ public abstract class OpenAiCompatibleService(
         }
 
         // No images - use standard AskAsync flow
+        await using var ingestedMemory = await CreateIngestedMemoryAsync(chat, memoryOptions, cancellationToken);
+        var kernel = ingestedMemory.Memory;
         MemoryAnswer retrievedContext;
         var standardTokens = new List<LLMTokenValue>();
 
@@ -684,7 +688,6 @@ public abstract class OpenAiCompatibleService(
             }
         }
 
-        await kernel.DeleteIndexAsync(cancellationToken: cancellationToken);
         return CreateChatResult(chat, retrievedContext.Result, standardTokens);
     }
 

--- a/src/MaIN.Services/Services/LLMService/OpenAiCompatibleService.cs
+++ b/src/MaIN.Services/Services/LLMService/OpenAiCompatibleService.cs
@@ -30,6 +30,8 @@ public abstract class OpenAiCompatibleService(
 {
     protected readonly INotificationService _notificationService = notificationService ?? throw new ArgumentNullException(nameof(notificationService));
     private readonly IHttpClientFactory _httpClientFactory = httpClientFactory ?? throw new ArgumentNullException(nameof(httpClientFactory));
+    protected readonly IMemoryFactory _memoryFactory = memoryFactory ?? throw new ArgumentNullException(nameof(memoryFactory));
+    protected readonly IMemoryService _memoryService = memoryService ?? throw new ArgumentNullException(nameof(memoryService));
 
     private static readonly ConcurrentDictionary<string, List<ChatMessage>> SessionCache = new();
     private static readonly HashSet<string> ImageExtensions = [".jpg", ".jpeg", ".png", ".gif", ".webp", ".bmp", ".tiff", ".tif", ".heic", ".heif", ".avif"];
@@ -71,7 +73,31 @@ public abstract class OpenAiCompatibleService(
         StringBuilder resultBuilder = new();
         if (HasFiles(lastMessage))
         {
-            var result = ChatHelper.ExtractMemoryOptions(lastMessage);
+            var memoryOptions = ChatHelper.ExtractMemoryOptions(lastMessage);
+
+            // If tools and memory are both configured, we treat memory as a tool.
+            if (chat.ToolsConfiguration?.Tools is { Count: > 0 })
+            {
+                var ingestedMemory = await CreateIngestedMemoryAsync(chat, memoryOptions, cancellationToken);
+                var originalTools = chat.ToolsConfiguration;
+                try
+                {
+                    chat.ToolsConfiguration = new ToolsConfiguration
+                    {
+                        Tools = [.. originalTools.Tools, FileSearchTool.Create(ingestedMemory, cancellationToken)],
+                        ToolChoice = originalTools.ToolChoice,
+                        MaxIterations = originalTools.MaxIterations
+                    };
+                    return await ProcessWithToolsAsync(chat, conversation, apiKey, tokens, options, cancellationToken);
+                }
+                finally
+                {
+                    chat.ToolsConfiguration = originalTools;
+                    await ingestedMemory.DisposeAsync();
+                }
+            }
+
+            var result = memoryOptions;
             var memoryResult = await AskMemory(chat, result, options, cancellationToken);
             resultBuilder.Append(memoryResult!.Message.Content);
             lastMessage.MarkProcessed();
@@ -463,6 +489,16 @@ public abstract class OpenAiCompatibleService(
         }
 
         return message?.ToolCalls;
+    }
+
+    protected virtual async Task<IIngestedMemory> CreateIngestedMemoryAsync(
+        Chat chat,
+        ChatMemoryOptions memoryOptions,
+        CancellationToken ct = default)
+    {
+        var kernel = _memoryFactory.CreateMemoryWithOpenAi(GetApiKey(), chat.MemoryParams);
+        await _memoryService.ImportDataToMemory((kernel, null), memoryOptions, ct);
+        return new IngestedMemory(kernel, () => kernel.DeleteIndexAsync(cancellationToken: ct));
     }
 
     public virtual async Task<ChatResult?> AskMemory(

--- a/src/MaIN.Services/Services/LLMService/OpenAiCompatibleService.cs
+++ b/src/MaIN.Services/Services/LLMService/OpenAiCompatibleService.cs
@@ -500,7 +500,7 @@ public abstract class OpenAiCompatibleService(
     {
         var kernel = _memoryFactory.CreateMemoryWithOpenAi(GetApiKey(), chat.MemoryParams);
         await _memoryService.ImportDataToMemory((kernel, null), memoryOptions, ct);
-        return new IngestedMemory(kernel, () => kernel.DeleteIndexAsync(cancellationToken: ct));
+        return new IngestedMemory(kernel, () => kernel.DeleteIndexAsync());
     }
 
     public virtual async Task<ChatResult?> AskMemory(

--- a/src/MaIN.Services/Services/LLMService/Utils/FileSearchTool.cs
+++ b/src/MaIN.Services/Services/LLMService/Utils/FileSearchTool.cs
@@ -1,0 +1,71 @@
+using System.Text.Json;
+using MaIN.Domain.Entities.Tools;
+using MaIN.Services.Services.LLMService.Memory;
+
+namespace MaIN.Services.Services.LLMService.Utils;
+
+internal static class FileSearchTool
+{
+    public const string Name = "search_documents";
+
+    private static readonly JsonSerializerOptions s_jsonOptions = new() { PropertyNameCaseInsensitive = true };
+
+    public static ToolDefinition Create(IIngestedMemory memory, CancellationToken ct = default)
+    {
+        return new ToolDefinition
+        {
+            Function = new()
+            {
+                Name = Name,
+                Description = """
+                    Search the attached documents for information relevant to the user's question.
+                    Call this tool whenever the answer may depend on the content of attached files.
+                    You can rephrase the query to improve retrieval accuracy."
+                    """,
+                Parameters = new
+                {
+                    type = "object",
+                    properties = new
+                    {
+                        query = new
+                        {
+                            type = "string",
+                            description = "Natural-language search query to run against the attached documents."
+                        }
+                    },
+                    required = new[] { "query" }
+                }
+            },
+            Execute = argsJson => ExecuteAsync(memory, argsJson, ct)
+        };
+    }
+
+    private static Task<string> ExecuteAsync(IIngestedMemory memory, string argsJson, CancellationToken ct)
+    {
+        var query = ExtractQuery(argsJson);
+        return memory.SearchAsync(query, ct);
+    }
+
+    private static string ExtractQuery(string argsJson)
+    {
+        if (string.IsNullOrWhiteSpace(argsJson))
+        {
+            return string.Empty;
+        }
+
+        try
+        {
+            using var doc = JsonDocument.Parse(argsJson);
+            if (doc.RootElement.TryGetProperty("query", out var queryElement))
+            {
+                return queryElement.GetString() ?? argsJson;
+            }
+        }
+        catch (JsonException)
+        {
+            // Raw string fallback — some local backends emit the query directly.
+        }
+
+        return argsJson;
+    }
+}

--- a/src/MaIN.Services/Services/LLMService/Utils/FileSearchTool.cs
+++ b/src/MaIN.Services/Services/LLMService/Utils/FileSearchTool.cs
@@ -8,8 +8,6 @@ internal static class FileSearchTool
 {
     public const string Name = "search_documents";
 
-    private static readonly JsonSerializerOptions s_jsonOptions = new() { PropertyNameCaseInsensitive = true };
-
     public static ToolDefinition Create(IIngestedMemory memory, CancellationToken ct = default)
     {
         return new ToolDefinition
@@ -56,12 +54,13 @@ internal static class FileSearchTool
         try
         {
             using var doc = JsonDocument.Parse(argsJson);
-            if (doc.RootElement.TryGetProperty("query", out var queryElement))
+            if (doc.RootElement.ValueKind == JsonValueKind.Object
+                && doc.RootElement.TryGetProperty("query", out var queryElement))
             {
                 return queryElement.GetString() ?? argsJson;
             }
         }
-        catch (JsonException)
+        catch (Exception ex) when (ex is JsonException or InvalidOperationException)
         {
             // Raw string fallback — some local backends emit the query directly.
         }

--- a/src/MaIN.Services/Services/LLMService/VertexService.cs
+++ b/src/MaIN.Services/Services/LLMService/VertexService.cs
@@ -127,7 +127,7 @@ public sealed class VertexService(
             chat.MemoryParams);
 
         await _memoryService.ImportDataToMemory((kernel, null), memoryOptions, ct);
-        return new IngestedMemory(kernel, () => kernel.DeleteIndexAsync(cancellationToken: ct));
+        return new IngestedMemory(kernel, () => kernel.DeleteIndexAsync());
     }
 
     /// <summary>

--- a/src/MaIN.Services/Services/LLMService/VertexService.cs
+++ b/src/MaIN.Services/Services/LLMService/VertexService.cs
@@ -110,7 +110,7 @@ public sealed class VertexService(
         return await base.Send(chat, options, cancellationToken);
     }
 
-    protected override async Task<IIngestedMemory> CreateIngestedMemoryAsync(
+    private protected override async Task<IIngestedMemory> CreateIngestedMemoryAsync(
         Chat chat,
         ChatMemoryOptions memoryOptions,
         CancellationToken ct = default)

--- a/src/MaIN.Services/Services/LLMService/VertexService.cs
+++ b/src/MaIN.Services/Services/LLMService/VertexService.cs
@@ -101,7 +101,7 @@ public sealed class VertexService(
         }
     }
 
-    public new async Task<ChatResult?> Send(
+    public override async Task<ChatResult?> Send(
         Chat chat,
         ChatRequestOptions options,
         CancellationToken cancellationToken = default)

--- a/src/MaIN.Services/Services/LLMService/VertexService.cs
+++ b/src/MaIN.Services/Services/LLMService/VertexService.cs
@@ -58,20 +58,47 @@ public sealed class VertexService(
     {
         var auth = Auth;
         if (string.IsNullOrEmpty(auth.ProjectId))
+        {
             throw new InvalidOperationException("GoogleServiceAccountConfig.ProjectId is required.");
+        }
+
         if (string.IsNullOrEmpty(auth.ClientEmail))
+        {
             throw new InvalidOperationException("GoogleServiceAccountConfig.ClientEmail is required.");
+        }
+
         if (string.IsNullOrEmpty(auth.PrivateKey))
+        {
             throw new InvalidOperationException("GoogleServiceAccountConfig.PrivateKey is required.");
+        }
     }
 
     protected override void ApplyBackendParams(Dictionary<string, object> requestBody, Chat chat)
     {
-        if (chat.BackendParams is not VertexInferenceParams p) return;
-        if (p.Temperature.HasValue) requestBody["temperature"] = p.Temperature.Value;
-        if (p.MaxTokens.HasValue) requestBody["max_tokens"] = p.MaxTokens.Value;
-        if (p.TopP.HasValue) requestBody["top_p"] = p.TopP.Value;
-        if (p.StopSequences is { Length: > 0 }) requestBody["stop"] = p.StopSequences;
+        if (chat.BackendParams is not VertexInferenceParams p)
+        {
+            return;
+        }
+
+        if (p.Temperature.HasValue)
+        {
+            requestBody["temperature"] = p.Temperature.Value;
+        }
+
+        if (p.MaxTokens.HasValue)
+        {
+            requestBody["max_tokens"] = p.MaxTokens.Value;
+        }
+
+        if (p.TopP.HasValue)
+        {
+            requestBody["top_p"] = p.TopP.Value;
+        }
+
+        if (p.StopSequences is { Length: > 0 })
+        {
+            requestBody["stop"] = p.StopSequences;
+        }
     }
 
     public new async Task<ChatResult?> Send(
@@ -81,6 +108,26 @@ public sealed class VertexService(
     {
         ExtractLocation(chat);
         return await base.Send(chat, options, cancellationToken);
+    }
+
+    protected override async Task<IIngestedMemory> CreateIngestedMemoryAsync(
+        Chat chat,
+        ChatMemoryOptions memoryOptions,
+        CancellationToken ct = default)
+    {
+        var auth = Auth;
+        _tokenProvider ??= new GoogleServiceAccountTokenProvider(auth);
+        var httpClient = _httpClientFactory.CreateClient(HttpClientName);
+        var tokenProvider = _tokenProvider;
+
+        var kernel = _memoryFactory.CreateMemoryWithVertex(
+            () => new ValueTask<string>(Task.Run(() => tokenProvider.GetAccessTokenAsync(httpClient))),
+            _location,
+            auth.ProjectId,
+            chat.MemoryParams);
+
+        await _memoryService.ImportDataToMemory((kernel, null), memoryOptions, ct);
+        return new IngestedMemory(kernel, () => kernel.DeleteIndexAsync(cancellationToken: ct));
     }
 
     /// <summary>
@@ -97,7 +144,9 @@ public sealed class VertexService(
         ExtractLocation(chat);
 
         if (!chat.Messages.Any())
+        {
             return null;
+        }
 
         var lastMessage = chat.Messages.Last();
         var originalContent = lastMessage.Content;
@@ -139,7 +188,9 @@ public sealed class VertexService(
     private static void CollectTextData(ChatMemoryOptions options, StringBuilder textContext)
     {
         foreach (var (name, content) in options.TextData)
+        {
             AppendDocument(textContext, name, content);
+        }
     }
 
     private static async Task CollectFilesData(
@@ -149,9 +200,13 @@ public sealed class VertexService(
         foreach (var (name, path) in options.FilesData)
         {
             if (IsNativeMultimodalFile(name))
+            {
                 inlineBytes.Add(await File.ReadAllBytesAsync(path, cancellationToken));
+            }
             else
+            {
                 AppendDocument(textContext, name, DocumentProcessor.ProcessDocument(path));
+            }
         }
     }
 
@@ -161,7 +216,11 @@ public sealed class VertexService(
     {
         foreach (var (name, stream) in options.StreamData)
         {
-            if (stream.CanSeek) stream.Position = 0;
+            if (stream.CanSeek)
+            {
+                stream.Position = 0;
+            }
+
             using var ms = new MemoryStream();
             await stream.CopyToAsync(ms, cancellationToken);
             var bytes = ms.ToArray();
@@ -180,7 +239,10 @@ public sealed class VertexService(
                 }
                 finally
                 {
-                    if (File.Exists(tempPath)) File.Delete(tempPath);
+                    if (File.Exists(tempPath))
+                    {
+                        File.Delete(tempPath);
+                    }
                 }
             }
         }
@@ -188,7 +250,11 @@ public sealed class VertexService(
 
     private static void CollectMemoryItems(ChatMemoryOptions options, StringBuilder textContext)
     {
-        if (options.Memory is not { Count: > 0 }) return;
+        if (options.Memory is not { Count: > 0 })
+        {
+            return;
+        }
+
         foreach (var item in options.Memory)
         {
             textContext.AppendLine(item);
@@ -212,6 +278,7 @@ public sealed class VertexService(
             query.Append(documentContext);
             query.AppendLine();
         }
+
         query.Append(userQuestion);
 
         if (grammar != null)
@@ -227,7 +294,9 @@ public sealed class VertexService(
     private static List<byte[]>? MergeInlineContent(List<byte[]>? existingImages, List<byte[]> newBytes)
     {
         if ((existingImages == null || existingImages.Count == 0) && newBytes.Count == 0)
+        {
             return null;
+        }
 
         var merged = new List<byte[]>(existingImages ?? []);
         merged.AddRange(newBytes);
@@ -239,6 +308,8 @@ public sealed class VertexService(
     private void ExtractLocation(Chat chat)
     {
         if (chat.BackendParams is VertexInferenceParams vp)
+        {
             _location = vp.Location;
+        }
     }
 }

--- a/src/MaIN.Services/Services/LLMService/XaiService.cs
+++ b/src/MaIN.Services/Services/LLMService/XaiService.cs
@@ -31,6 +31,7 @@ public sealed class XaiService(
     protected override string ChatCompletionsUrl => ServiceConstants.ApiUrls.XaiOpenAiChatCompletions;
     protected override string ModelsUrl => ServiceConstants.ApiUrls.XaiModels;
     protected override Type ExpectedParamsType => typeof(XaiInferenceParams);
+    protected override bool SupportsSemanticSearch => false;
 
     protected override string GetApiKey()
     {


### PR DESCRIPTION
Previously when with files and with tools were configured, the chat silently ignored the tools. This PR introduces an approach where files RAG is added to the tools list so the model can call the RAG if needed. Tool only and file only chats bahaves as before.

New tests added and all pass.

Fixes #114 